### PR TITLE
fix-bug-in-factory

### DIFF
--- a/src/Fame-Core/FM3Package.class.st
+++ b/src/Fame-Core/FM3Package.class.st
@@ -43,6 +43,11 @@ FM3Package >> classNamed: aString ifAbsent: aBlock [
 	^ classes byName: aString ifAbsent: aBlock
 ]
 
+{ #category : #'accessing-query' }
+FM3Package >> classNamed: aString ifPresent: aBlock ifAbsent: anotherBlock [
+	^ classes byName: aString ifPresent: aBlock ifAbsent: anotherBlock
+]
+
 { #category : #accessing }
 FM3Package >> classes [
 	<FMProperty: #classes type: #FM3Class opposite: #package>

--- a/src/Fame-Core/FMMetamodelFactory.class.st
+++ b/src/Fame-Core/FMMetamodelFactory.class.st
@@ -34,7 +34,7 @@ FMMetamodelFactory >> entityNamed: aString [
 FMMetamodelFactory >> entityNamed: aString ifAbsent: aBlock [
 	self fm3Package ifNil: [ ^ aBlock value ].
 
-	^ (self fm3Package classNamed: aString ifAbsent: aBlock) implementingClass
+	^ self fm3Package classNamed: aString ifPresent: #implementingClass ifAbsent: aBlock
 ]
 
 { #category : #accessing }

--- a/src/Fame-Core/FMMultivalueLink.class.st
+++ b/src/Fame-Core/FMMultivalueLink.class.st
@@ -100,11 +100,17 @@ FMMultivalueLink >> byName: name [
 
 { #category : #accessing }
 FMMultivalueLink >> byName: name ifAbsent: exceptionBlock [
+	^ values
+		detect: [ :each | each name asString = name asString ]
+		ifNone: exceptionBlock
+]
 
-	^values
-			detect: [ :each | each name asString = name asString ]
-			ifNone: exceptionBlock
-	 
+{ #category : #accessing }
+FMMultivalueLink >> byName: name ifPresent: aBlock ifAbsent: exceptionBlock [
+	^ values
+		detect: [ :each | each name asString = name asString ]
+		ifFound: aBlock
+		ifNone: exceptionBlock
 ]
 
 { #category : #enumerating }

--- a/src/Fame-Core/FMSlotMultivalueLink.class.st
+++ b/src/Fame-Core/FMSlotMultivalueLink.class.st
@@ -67,11 +67,17 @@ FMSlotMultivalueLink >> byName: name [
 
 { #category : #accessing }
 FMSlotMultivalueLink >> byName: name ifAbsent: exceptionBlock [
+	^ values
+		detect: [ :each | each name asString = name asString ]
+		ifNone: exceptionBlock
+]
 
-	^values
-			detect: [ :each | each name asString = name asString ]
-			ifNone: exceptionBlock
-	 
+{ #category : #accessing }
+FMSlotMultivalueLink >> byName: name ifPresent: aBlock ifAbsent: exceptionBlock [
+	^ values
+		detect: [ :each | each name asString = name asString ]
+		ifFound: aBlock
+		ifNone: exceptionBlock
 ]
 
 { #category : #enumerating }

--- a/src/Fame-Deprecated/FMNullMultivalueLink.class.st
+++ b/src/Fame-Deprecated/FMNullMultivalueLink.class.st
@@ -57,7 +57,12 @@ FMNullMultivalueLink >> basicIterator [
 
 { #category : #accessing }
 FMNullMultivalueLink >> byName: aName ifAbsent: aBlock [
-	^aBlock value
+	^ aBlock value
+]
+
+{ #category : #accessing }
+FMNullMultivalueLink >> byName: name ifPresent: aBlock ifAbsent: exceptionBlock [
+	^ exceptionBlock value
 ]
 
 { #category : #enumerating }


### PR DESCRIPTION
FMMetamodelFactory>>#entityNamed:ifAbsent: failed its absent block

FIx bug where FMMetamodelFactory>>#entityNamed:ifAbsent: was sending #implementingClass on the result of the #ifAbsent: block in case nothing was found.