### PR TITLE
speed-up-relation-slot-writing

### DIFF
--- a/src/Fame-Core/FMOne.class.st
+++ b/src/Fame-Core/FMOne.class.st
@@ -22,16 +22,18 @@ FMOne >> isToOne [
 	^ true
 ]
 
-{ #category : #'meta-object-protocol' }
-FMOne >> write: newValue to: anObject [
-	| oldValue |
-	oldValue := self read: anObject.
-
+{ #category : #internal }
+FMOne >> updateOld: oldValue new: newValue in: anObject [
 	self hasInverse
 		ifTrue: [ oldValue ifNotNil: [ self removeAssociationFrom: anObject to: oldValue ].
 			newValue ifNotNil: [ self addAssociationFrom: anObject to: newValue ] ].
 
 	super write: newValue to: anObject
+]
+
+{ #category : #'meta-object-protocol' }
+FMOne >> write: newValue to: anObject [
+	self updateOld: (self read: anObject) new: newValue in: anObject
 ]
 
 { #category : #internal }

--- a/src/Fame-Core/FMRelationSlot.class.st
+++ b/src/Fame-Core/FMRelationSlot.class.st
@@ -60,15 +60,17 @@ FMRelationSlot >> addAssociationFrom: ownerObject to: otherObject [
 { #category : #'code generation' }
 FMRelationSlot >> emitStore: aMethodBuilder [
 	| tempName |
-	tempName := Object new.
+	tempName := '0slotTempForStackManipulation'.
 	aMethodBuilder
 		addTemp: tempName;
 		storeTemp: tempName;
 		popTop;
-		pushReceiver;
-		pushLiteralVariable: (AdditionalBinding key: #slot value: self);
+		pushLiteral: self;
+		pushInstVar: index;
 		pushTemp: tempName;
-		send: #writeSlot:value:
+		pushReceiver;
+		send: #updateOld:new:in:;
+		storeInstVar: index
 ]
 
 { #category : #'code generation' }

--- a/src/Fame-Core/FMRelationSlot.class.st
+++ b/src/Fame-Core/FMRelationSlot.class.st
@@ -26,7 +26,8 @@ Class {
 	#superclass : #InstanceVariableSlot,
 	#instVars : [
 		'targetClass',
-		'inverseName'
+		'inverseName',
+		'inverseSlotDic'
 	],
 	#category : #'Fame-Core-Utilities'
 }
@@ -104,6 +105,12 @@ FMRelationSlot >> inClass: aTargetClassOrSymbol [
 ]
 
 { #category : #initialization }
+FMRelationSlot >> initialize [
+	super initialize.
+	inverseSlotDic := IdentityDictionary new
+]
+
+{ #category : #initialization }
 FMRelationSlot >> inverse: anInverseSymbol inClass: aTargetClassOrSymbol [
 	self inClass: aTargetClassOrSymbol.
 	inverseName := anInverseSymbol
@@ -166,7 +173,7 @@ FMRelationSlot >> printOn: aStream [
 
 { #category : #accessing }
 FMRelationSlot >> realInverseSlotFor: anObject [
-	^ anObject class slotNamed: self inverseName
+	^ inverseSlotDic at: anObject class ifAbsentPut: [ anObject class slotNamed: self inverseName ]
 ]
 
 { #category : #internal }


### PR DESCRIPTION
Speed up writing in FMRelationSlot.```stc := FamixStClass new.m := FamixStMethod new.[ m parentType: c ] bench."'595156.675 per second'""'1702087.530 per second'"```- Do not use reflectivity in bytecode of the FMRelationSlot - Add a cache to remember the opposites of a slot