### PR TITLE
Create fm3 trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Note you can replace the #master by another branch such as #development or a tag
 
 TODO
 
+### Export to mse
+
+To export a model (or metamodel) in the mse format (for example to use FameJava and VerveineJ), execute the following code:
+
+```Smalltalk
+'/path/to/file.mse' asFileReference writeStreamDo: [ :writeStream | MyModel metamodel exportOn: writeStream ]
+```
+
 ## Version management 
 
 This project use semantic versioning to define the releases. This means that each stable release of the project will be assigned a version number of the form `vX.Y.Z`. 

--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -72,15 +72,11 @@ FM3Class >> allPrimitiveProperties [
 	^ self allProperties select: [ :attr | attr type isNotNil and: [ attr type isPrimitive ] ]
 ]
 
-{ #category : #'accessing-query' }
-FM3Class >> allProperties [
-	<FMProperty: #allProperties type: 'FM3.Property'>
-	<multivalued>
-	<derived>
-	| nameDict |
-	nameDict := Dictionary new: 60.	"estimated initial size."
-	self allPropertiesDo: [ :each | nameDict at: each name ifAbsentPut: [ each ] ].
-	^ nameDict values asArray
+{ #category : #enumerating }
+FM3Class >> allPropertiesDo: block [
+	properties do: block.
+	self superclass ifNotNil: [ :class | class allPropertiesDo: block ].
+	self traits do: [ :trait | trait allPropertiesDo: block ]
 ]
 
 { #category : #accessing }
@@ -215,23 +211,6 @@ FM3Class >> ownerProperties [
 { #category : #'accessing-query' }
 FM3Class >> primitiveProperties [
 	^ self properties select: [ :attr | attr type isPrimitive ]
-]
-
-{ #category : #'accessing-query' }
-FM3Class >> propertiesNamed: aListOfSymbol [
-	^ aListOfSymbol collect: [ :each | self propertyNamed: each ]
-]
-
-{ #category : #'accessing-query' }
-FM3Class >> propertyNamed: aString [
-	^ self propertyNamed: aString ifAbsent: nil
-]
-
-{ #category : #'accessing-query' }
-FM3Class >> propertyNamed: aString ifAbsent: aBlock [
-	self allPropertiesDo: [ :attr | attr name = aString ifTrue: [ ^ attr ] ].
-
-	^ aBlock value
 ]
 
 { #category : #accessing }

--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -30,15 +30,12 @@ Internal Representation and Key Implementation Points.
 "
 Class {
 	#name : #FM3Class,
-	#superclass : #FM3Element,
+	#superclass : #FM3Type,
 	#instVars : [
 		'isAbstract',
 		'superclass',
-		'package',
 		'implementingClass',
-		'subclasses',
-		'traits',
-		'properties'
+		'subclasses'
 	],
 	#category : #'Fame-Core-Model'
 }
@@ -58,11 +55,6 @@ FM3Class class >> defaultSuperclass [
 { #category : #visiting }
 FM3Class >> accept: aVisitor [
 	aVisitor visitClass: self
-]
-
-{ #category : #adding }
-FM3Class >> addTraits: aCollection [
-	self traits addAll: aCollection
 ]
 
 { #category : #'accessing-query' }
@@ -89,13 +81,6 @@ FM3Class >> allProperties [
 	nameDict := Dictionary new: 60.	"estimated initial size."
 	self allPropertiesDo: [ :each | nameDict at: each name ifAbsentPut: [ each ] ].
 	^ nameDict values asArray
-]
-
-{ #category : #enumerating }
-FM3Class >> allPropertiesDo: block [
-	properties do: block.
-	self superclass ifNotNil: [ :class | class allPropertiesDo: block ].
-	self traits do: [ :trait | trait allPropertiesDo: block ]
 ]
 
 { #category : #accessing }
@@ -172,11 +157,9 @@ FM3Class >> inheritsFrom: aClass [
 { #category : #initialization }
 FM3Class >> initialize [
 	super initialize.
-	properties := FMMultivalueLink on: self opposite: #mmClass:.
 	isAbstract := false.
 	superclass := self class defaultSuperclass.
-	subclasses := FMMultivalueLink on: self opposite: #superclass:.
-	traits := Set new
+	subclasses := FMMultivalueLink on: self opposite: #superclass:
 ]
 
 { #category : #testing }
@@ -229,37 +212,9 @@ FM3Class >> ownerProperties [
 	^ self allProperties select: #isContainer
 ]
 
-{ #category : #accessing }
-FM3Class >> package [
-	<FMProperty: #package type: #FM3Package opposite: #classes>
-	<container>
-	^ package
-]
-
-{ #category : #accessing }
-FM3Class >> package: newPackage [
-	package := FMMultivalueLink
-		on: self
-		update: #classes
-		from: self package
-		to: newPackage
-]
-
 { #category : #'accessing-query' }
 FM3Class >> primitiveProperties [
 	^ self properties select: [ :attr | attr type isPrimitive ]
-]
-
-{ #category : #accessing }
-FM3Class >> properties [
-	<FMProperty: #properties type: 'FM3.Property' opposite: #class>
-	<multivalued>
-	^ properties
-]
-
-{ #category : #accessing }
-FM3Class >> properties: anObject [
-	properties value: anObject
 ]
 
 { #category : #'accessing-query' }
@@ -305,13 +260,6 @@ FM3Class >> superclass: newClass [
 		update: #subclasses
 		from: self superclass
 		to: newClass
-]
-
-{ #category : #accessing }
-FM3Class >> traits [
-	<FMProperty: #traits type: #FM3Class>
-	<multivalued>
-	^ traits
 ]
 
 { #category : #accessing }

--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -42,7 +42,7 @@ Class {
 
 { #category : #meta }
 FM3Class class >> annotation [
-	<FMClass: #Class super: #FM3Element>
+	<FMClass: #Class super: #FM3Type>
 	<package: #FM3>
 
 ]

--- a/src/Fame-Core/FM3Package.class.st
+++ b/src/Fame-Core/FM3Package.class.st
@@ -50,7 +50,7 @@ FM3Package >> classNamed: aString ifPresent: aBlock ifAbsent: anotherBlock [
 
 { #category : #accessing }
 FM3Package >> classes [
-	<FMProperty: #classes type: #FM3Class opposite: #package>
+	<FMProperty: #classes type: #FM3Type opposite: #package>
 	<multivalued>
 	^ classes
 ]

--- a/src/Fame-Core/FM3Property.class.st
+++ b/src/Fame-Core/FM3Property.class.st
@@ -223,7 +223,7 @@ FM3Property >> isTarget: anObject [
 
 { #category : #accessing }
 FM3Property >> mmClass [
-	<FMProperty: #class type: #FM3Class opposite: #properties>
+	<FMProperty: #class type: #FM3Type opposite: #properties>
 	<container>
 	
 	^class 

--- a/src/Fame-Core/FM3Trait.class.st
+++ b/src/Fame-Core/FM3Trait.class.st
@@ -34,23 +34,6 @@ FM3Trait >> allPrimitiveProperties [
 	^ self allProperties select: [ :attr | attr type isNotNil and: [ attr type isPrimitive ] ]
 ]
 
-{ #category : #'accessing-query' }
-FM3Trait >> allProperties [
-	<FMProperty: #allProperties type: 'FM3.Property'>
-	<multivalued>
-	<derived>
-	| nameDict |
-	nameDict := Dictionary new: 60.	"estimated initial size."
-	self allPropertiesDo: [ :each | nameDict at: each name ifAbsentPut: [ each ] ].
-	^ nameDict values asArray
-]
-
-{ #category : #enumerating }
-FM3Trait >> allPropertiesDo: block [
-	self properties do: block.
-	self traits do: [ :trait | trait allPropertiesDo: block ]
-]
-
 { #category : #accessing }
 FM3Trait >> allSuperclasses [
 	| mmclass superclasses |
@@ -149,35 +132,6 @@ FM3Trait >> ownerProperties [
 { #category : #'accessing-query' }
 FM3Trait >> primitiveProperties [
 	^ self properties select: [ :attr | attr type isPrimitive ]
-]
-
-{ #category : #accessing }
-FM3Trait >> properties [
-	<FMProperty: #properties type: 'FM3.Property' opposite: #class>
-	<multivalued>
-	^ properties
-]
-
-{ #category : #accessing }
-FM3Trait >> properties: anObject [
-	properties value: anObject
-]
-
-{ #category : #'accessing-query' }
-FM3Trait >> propertiesNamed: aListOfSymbol [
-	^ aListOfSymbol collect: [ :each | self propertyNamed: each ]
-]
-
-{ #category : #'accessing-query' }
-FM3Trait >> propertyNamed: aString [
-	^ self propertyNamed: aString ifAbsent: nil
-]
-
-{ #category : #'accessing-query' }
-FM3Trait >> propertyNamed: aString ifAbsent: aBlock [
-	self allPropertiesDo: [ :attr | attr name = aString ifTrue: [ ^ attr ] ].
-
-	^ aBlock value
 ]
 
 { #category : #accessing }

--- a/src/Fame-Core/FM3Trait.class.st
+++ b/src/Fame-Core/FM3Trait.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : #FM3Trait,
 	#superclass : #FM3Type,
 	#instVars : [
-		'superclass',
 		'implementingClass'
 	],
 	#category : #'Fame-Core-Model'
@@ -10,14 +9,9 @@ Class {
 
 { #category : #meta }
 FM3Trait class >> annotation [
-	<FMClass: #Trait super: #FM3Element>
+	<FMClass: #Trait super: #FM3Type>
 	<package: #FM3>
 
-]
-
-{ #category : #accessing }
-FM3Trait class >> defaultSuperclass [
-	^ FM3TraitConstant instance
 ]
 
 { #category : #visiting }
@@ -53,8 +47,7 @@ FM3Trait >> allProperties [
 
 { #category : #enumerating }
 FM3Trait >> allPropertiesDo: block [
-	properties do: block.
-	self superclass ifNotNil: [ :class | class allPropertiesDo: block ].
+	self properties do: block.
 	self traits do: [ :trait | trait allPropertiesDo: block ]
 ]
 
@@ -92,11 +85,6 @@ FM3Trait >> hasPackage [
 	^ package isNotNil
 ]
 
-{ #category : #testing }
-FM3Trait >> hasSuperclass [
-	^ superclass isNotNil
-]
-
 { #category : #accessing }
 FM3Trait >> implementingClass [
 	^ implementingClass
@@ -111,12 +99,6 @@ FM3Trait >> implementingClass: smalltalkClass [
 FM3Trait >> inheritsFrom: aClass [
 	self allSuperclassesDo: [ :each | each = aClass ifTrue: [ ^ true ] ].
 	^ false
-]
-
-{ #category : #initialization }
-FM3Trait >> initialize [
-	super initialize.
-	superclass := self class defaultSuperclass.
 ]
 
 { #category : #accessing }
@@ -136,7 +118,7 @@ FM3Trait >> isConstant [
 ]
 
 { #category : #testing }
-FM3Trait >> isFM3Class [
+FM3Trait >> isFM3Trait [
 	^ true
 ]
 
@@ -196,21 +178,6 @@ FM3Trait >> propertyNamed: aString ifAbsent: aBlock [
 	self allPropertiesDo: [ :attr | attr name = aString ifTrue: [ ^ attr ] ].
 
 	^ aBlock value
-]
-
-{ #category : #accessing }
-FM3Trait >> superclass [
-	<FMProperty: #superclass type: #FM3Class opposite: #subclasses>
-	^ superclass
-]
-
-{ #category : #accessing }
-FM3Trait >> superclass: newClass [
-	superclass := FMMultivalueLink
-		on: self
-		update: #subclasses
-		from: self superclass
-		to: newClass
 ]
 
 { #category : #accessing }

--- a/src/Fame-Core/FM3Trait.class.st
+++ b/src/Fame-Core/FM3Trait.class.st
@@ -1,13 +1,9 @@
 Class {
 	#name : #FM3Trait,
-	#superclass : #FM3Element,
+	#superclass : #FM3Type,
 	#instVars : [
 		'superclass',
-		'package',
-		'implementingClass',
-		'subclasses',
-		'traits',
-		'properties'
+		'implementingClass'
 	],
 	#category : #'Fame-Core-Model'
 }
@@ -26,12 +22,7 @@ FM3Trait class >> defaultSuperclass [
 
 { #category : #visiting }
 FM3Trait >> accept: aVisitor [
-	aVisitor visitClass: self
-]
-
-{ #category : #adding }
-FM3Trait >> addTraits: aCollection [
-	self traits addAll: aCollection
+	aVisitor visitTrait: self
 ]
 
 { #category : #'accessing-query' }
@@ -125,9 +116,7 @@ FM3Trait >> inheritsFrom: aClass [
 { #category : #initialization }
 FM3Trait >> initialize [
 	super initialize.
-	properties := FMMultivalueLink on: self opposite: #mmClass:.
 	superclass := self class defaultSuperclass.
-	traits := Set new
 ]
 
 { #category : #accessing }
@@ -173,22 +162,6 @@ FM3Trait >> owner [
 { #category : #'accessing-query' }
 FM3Trait >> ownerProperties [
 	^ self allProperties select: #isContainer
-]
-
-{ #category : #accessing }
-FM3Trait >> package [
-	<FMProperty: #package type: #FM3Package opposite: #classes>
-	<container>
-	^ package
-]
-
-{ #category : #accessing }
-FM3Trait >> package: newPackage [
-	package := FMMultivalueLink
-		on: self
-		update: #classes
-		from: self package
-		to: newPackage
 ]
 
 { #category : #'accessing-query' }
@@ -238,20 +211,6 @@ FM3Trait >> superclass: newClass [
 		update: #subclasses
 		from: self superclass
 		to: newClass
-]
-
-{ #category : #accessing }
-FM3Trait >> traits [
-	<FMProperty: #traits type: #FM3Class>
-	<multivalued>
-	^ traits
-]
-
-{ #category : #accessing }
-FM3Trait >> withAllSubclasses [
-	^ self allSubclasses
-		add: self;
-		yourself
 ]
 
 { #category : #accessing }

--- a/src/Fame-Core/FM3Trait.class.st
+++ b/src/Fame-Core/FM3Trait.class.st
@@ -1,0 +1,262 @@
+Class {
+	#name : #FM3Trait,
+	#superclass : #FM3Element,
+	#instVars : [
+		'superclass',
+		'package',
+		'implementingClass',
+		'subclasses',
+		'traits',
+		'properties'
+	],
+	#category : #'Fame-Core-Model'
+}
+
+{ #category : #meta }
+FM3Trait class >> annotation [
+	<FMClass: #Trait super: #FM3Element>
+	<package: #FM3>
+
+]
+
+{ #category : #accessing }
+FM3Trait class >> defaultSuperclass [
+	^ FM3TraitConstant instance
+]
+
+{ #category : #visiting }
+FM3Trait >> accept: aVisitor [
+	aVisitor visitClass: self
+]
+
+{ #category : #adding }
+FM3Trait >> addTraits: aCollection [
+	self traits addAll: aCollection
+]
+
+{ #category : #'accessing-query' }
+FM3Trait >> allComplexProperties [
+	^ self allProperties reject: [ :attr | attr type isNotNil and: [ attr type isPrimitive ] ]
+]
+
+{ #category : #'accessing-query' }
+FM3Trait >> allContainerProperties [
+	^ self allProperties select: #isContainer
+]
+
+{ #category : #'accessing-query' }
+FM3Trait >> allPrimitiveProperties [
+	^ self allProperties select: [ :attr | attr type isNotNil and: [ attr type isPrimitive ] ]
+]
+
+{ #category : #'accessing-query' }
+FM3Trait >> allProperties [
+	<FMProperty: #allProperties type: 'FM3.Property'>
+	<multivalued>
+	<derived>
+	| nameDict |
+	nameDict := Dictionary new: 60.	"estimated initial size."
+	self allPropertiesDo: [ :each | nameDict at: each name ifAbsentPut: [ each ] ].
+	^ nameDict values asArray
+]
+
+{ #category : #enumerating }
+FM3Trait >> allPropertiesDo: block [
+	properties do: block.
+	self superclass ifNotNil: [ :class | class allPropertiesDo: block ].
+	self traits do: [ :trait | trait allPropertiesDo: block ]
+]
+
+{ #category : #accessing }
+FM3Trait >> allSuperclasses [
+	| mmclass superclasses |
+	superclasses := OrderedCollection new.
+	mmclass := self.
+
+	[ mmclass hasSuperclass ]
+		whileTrue: [ mmclass := mmclass superclass.
+			superclasses add: mmclass ].
+	^ superclasses
+]
+
+{ #category : #accessing }
+FM3Trait >> allSuperclassesDo: aBlock [
+	self allSuperclasses do: [ :each | aBlock value: each ]
+]
+
+{ #category : #'accessing-query' }
+FM3Trait >> complexProperties [
+	^ self properties reject: [ :attr | attr type isPrimitive ]
+]
+
+{ #category : #'instance creation' }
+FM3Trait >> createInstance [
+	^ implementingClass
+		ifNil: [ FMRuntimeElement new description: self ]
+		ifNotNil: [ implementingClass new ]
+]
+
+{ #category : #testing }
+FM3Trait >> hasPackage [
+	^ package isNotNil
+]
+
+{ #category : #testing }
+FM3Trait >> hasSuperclass [
+	^ superclass isNotNil
+]
+
+{ #category : #accessing }
+FM3Trait >> implementingClass [
+	^ implementingClass
+]
+
+{ #category : #accessing }
+FM3Trait >> implementingClass: smalltalkClass [
+	implementingClass := smalltalkClass
+]
+
+{ #category : #accessing }
+FM3Trait >> inheritsFrom: aClass [
+	self allSuperclassesDo: [ :each | each = aClass ifTrue: [ ^ true ] ].
+	^ false
+]
+
+{ #category : #initialization }
+FM3Trait >> initialize [
+	super initialize.
+	properties := FMMultivalueLink on: self opposite: #mmClass:.
+	superclass := self class defaultSuperclass.
+	traits := Set new
+]
+
+{ #category : #accessing }
+FM3Trait >> isAbstract [
+	self flag: 'This is for compatibility purpose'.
+	^ true
+]
+
+{ #category : #testing }
+FM3Trait >> isBuiltIn [
+	^ self isPrimitive or: [ self isRoot ]
+]
+
+{ #category : #testing }
+FM3Trait >> isConstant [
+	^ false
+]
+
+{ #category : #testing }
+FM3Trait >> isFM3Class [
+	^ true
+]
+
+{ #category : #testing }
+FM3Trait >> isPrimitive [
+	<FMProperty: #primitive type: #Boolean>
+	<derived>
+	^ false
+]
+
+{ #category : #testing }
+FM3Trait >> isRoot [
+	<FMProperty: #root type: #Boolean>
+	<derived>
+	^ false
+]
+
+{ #category : #accessing }
+FM3Trait >> owner [
+	^ self package
+]
+
+{ #category : #'accessing-query' }
+FM3Trait >> ownerProperties [
+	^ self allProperties select: #isContainer
+]
+
+{ #category : #accessing }
+FM3Trait >> package [
+	<FMProperty: #package type: #FM3Package opposite: #classes>
+	<container>
+	^ package
+]
+
+{ #category : #accessing }
+FM3Trait >> package: newPackage [
+	package := FMMultivalueLink
+		on: self
+		update: #classes
+		from: self package
+		to: newPackage
+]
+
+{ #category : #'accessing-query' }
+FM3Trait >> primitiveProperties [
+	^ self properties select: [ :attr | attr type isPrimitive ]
+]
+
+{ #category : #accessing }
+FM3Trait >> properties [
+	<FMProperty: #properties type: 'FM3.Property' opposite: #class>
+	<multivalued>
+	^ properties
+]
+
+{ #category : #accessing }
+FM3Trait >> properties: anObject [
+	properties value: anObject
+]
+
+{ #category : #'accessing-query' }
+FM3Trait >> propertiesNamed: aListOfSymbol [
+	^ aListOfSymbol collect: [ :each | self propertyNamed: each ]
+]
+
+{ #category : #'accessing-query' }
+FM3Trait >> propertyNamed: aString [
+	^ self propertyNamed: aString ifAbsent: nil
+]
+
+{ #category : #'accessing-query' }
+FM3Trait >> propertyNamed: aString ifAbsent: aBlock [
+	self allPropertiesDo: [ :attr | attr name = aString ifTrue: [ ^ attr ] ].
+
+	^ aBlock value
+]
+
+{ #category : #accessing }
+FM3Trait >> superclass [
+	<FMProperty: #superclass type: #FM3Class opposite: #subclasses>
+	^ superclass
+]
+
+{ #category : #accessing }
+FM3Trait >> superclass: newClass [
+	superclass := FMMultivalueLink
+		on: self
+		update: #subclasses
+		from: self superclass
+		to: newClass
+]
+
+{ #category : #accessing }
+FM3Trait >> traits [
+	<FMProperty: #traits type: #FM3Class>
+	<multivalued>
+	^ traits
+]
+
+{ #category : #accessing }
+FM3Trait >> withAllSubclasses [
+	^ self allSubclasses
+		add: self;
+		yourself
+]
+
+{ #category : #accessing }
+FM3Trait >> withAllSuperclasses [
+	^ self allSuperclasses
+		add: self;
+		yourself
+]

--- a/src/Fame-Core/FM3TraitConstant.class.st
+++ b/src/Fame-Core/FM3TraitConstant.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #FM3TraitConstant,
+	#superclass : #FM3Constant,
+	#category : #'Fame-Core-Model'
+}
+
+{ #category : #accessing }
+FM3TraitConstant class >> constantName [
+	^ #Trait
+]
+
+{ #category : #'accessing-query' }
+FM3TraitConstant class >> defaultSuperclass [
+	^ nil
+]
+
+{ #category : #testing }
+FM3TraitConstant >> isRoot [
+	^ true
+]

--- a/src/Fame-Core/FM3Type.class.st
+++ b/src/Fame-Core/FM3Type.class.st
@@ -1,0 +1,76 @@
+Class {
+	#name : #FM3Type,
+	#superclass : #FM3Element,
+	#instVars : [
+		'package',
+		'properties',
+		'traits'
+	],
+	#category : #'Fame-Core-Model'
+}
+
+{ #category : #meta }
+FM3Type class >> annotation [
+	<FMClass: #Type super: #FM3Element>
+	<package: #FM3>
+
+]
+
+{ #category : #accessing }
+FM3Type class >> defaultSuperclass [
+	^ FM3Object instance
+]
+
+{ #category : #adding }
+FM3Type >> addTraits: aCollection [
+	self traits addAll: aCollection
+]
+
+{ #category : #enumerating }
+FM3Type >> allPropertiesDo: block [
+	properties do: block.
+	self superclass ifNotNil: [ :class | class allPropertiesDo: block ].
+	self traits do: [ :trait | trait allPropertiesDo: block ]
+]
+
+{ #category : #accessing }
+FM3Type >> initialize [
+	super initialize.
+	properties := FMMultivalueLink on: self opposite: #mmClass:.
+	traits := Set new
+]
+
+{ #category : #accessing }
+FM3Type >> package [
+	<FMProperty: #package type: #FM3Package opposite: #classes>
+	<container>
+	^ package
+]
+
+{ #category : #accessing }
+FM3Type >> package: newPackage [
+	package := FMMultivalueLink
+		on: self
+		update: #classes
+		from: self package
+		to: newPackage
+]
+
+{ #category : #accessing }
+FM3Type >> properties [
+	<FMProperty: #properties type: 'FM3.Property' opposite: #class>
+	<multivalued>
+	^ properties
+]
+
+{ #category : #accessing }
+FM3Type >> properties: anObject [
+	properties value: anObject
+]
+
+{ #category : #accessing }
+FM3Type >> traits [
+	<FMProperty: #traits type: #FM3Trait>
+	<multivalued>
+	^ traits
+]

--- a/src/Fame-Core/FM3Type.class.st
+++ b/src/Fame-Core/FM3Type.class.st
@@ -26,10 +26,20 @@ FM3Type >> addTraits: aCollection [
 	self traits addAll: aCollection
 ]
 
+{ #category : #'accessing-query' }
+FM3Type >> allProperties [
+	<FMProperty: #allProperties type: 'FM3.Property'>
+	<multivalued>
+	<derived>
+	| nameDict |
+	nameDict := Dictionary new: 60.	"estimated initial size."
+	self allPropertiesDo: [ :each | nameDict at: each name ifAbsentPut: [ each ] ].
+	^ nameDict values asArray
+]
+
 { #category : #enumerating }
 FM3Type >> allPropertiesDo: block [
-	properties do: block.
-	self superclass ifNotNil: [ :class | class allPropertiesDo: block ].
+	self properties do: block.
 	self traits do: [ :trait | trait allPropertiesDo: block ]
 ]
 
@@ -66,6 +76,23 @@ FM3Type >> properties [
 { #category : #accessing }
 FM3Type >> properties: anObject [
 	properties value: anObject
+]
+
+{ #category : #'accessing-query' }
+FM3Type >> propertiesNamed: aListOfSymbol [
+	^ aListOfSymbol collect: [ :each | self propertyNamed: each ]
+]
+
+{ #category : #'accessing-query' }
+FM3Type >> propertyNamed: aString [
+	^ self propertyNamed: aString ifAbsent: nil
+]
+
+{ #category : #'accessing-query' }
+FM3Type >> propertyNamed: aString ifAbsent: aBlock [
+	self allPropertiesDo: [ :attr | attr name = aString ifTrue: [ ^ attr ] ].
+
+	^ aBlock value
 ]
 
 { #category : #accessing }

--- a/src/Fame-Core/FMGenericModelVisitor.class.st
+++ b/src/Fame-Core/FMGenericModelVisitor.class.st
@@ -31,3 +31,9 @@ FMGenericModelVisitor >> visitPackage: aFM3Package [
 FMGenericModelVisitor >> visitProperty: aFM3Property [
 	^ self visitElement: aFM3Property
 ]
+
+{ #category : #visiting }
+FMGenericModelVisitor >> visitTrait: aFM3Trait [
+	self visitElement: aFM3Trait.
+	^ super visitTrait: aFM3Trait
+]

--- a/src/Fame-Core/FMMetaModel.class.st
+++ b/src/Fame-Core/FMMetaModel.class.st
@@ -130,6 +130,11 @@ FMMetaModel >> properties [
 	^ self elements select: [ :each | each isFM3Property ]
 ]
 
+{ #category : #accessing }
+FMMetaModel >> traits [
+	^ self elements select: [ :each | each isFM3Trait ]
+]
+
 { #category : #private }
 FMMetaModel >> updateCache [
 	nameDict := (FM3Constant constants collect: [ :const | const name asString -> const ]) asDictionary.

--- a/src/Fame-Core/FMMetaModelBuilder.class.st
+++ b/src/Fame-Core/FMMetaModelBuilder.class.st
@@ -204,23 +204,26 @@ FMMetaModelBuilder >> processClass: aClass [
 
 { #category : #private }
 FMMetaModelBuilder >> processClass: aClass ifPragmaAbsent: anErrorBlock [
-	aClass metamodelDefinitionPragma
-		ifNil: anErrorBlock
-		ifNotNil: [ :pragma | 
-			| fm3Class |
-			fm3Class := FM3Class named: (pragma argumentAt: 1).
-			superclassDict at: fm3Class put: (pragma argumentAt: 2).
-			fm3Class implementingClass: aClass.
-
-			(pragma method pragmaAt: #abstract) ifNotNil: [ fm3Class isAbstract: true ].
-			self extractPackageFrom: pragma method for: fm3Class.
-			classDict at: aClass put: fm3Class.
-			(self methodsToProcessFrom: aClass) do: [ :each | self processCompiledMethod: each ].
-			aClass localSlots select: #isFMRelationSlot thenDo: [ :each | self processSlot: each in: aClass ].
-
-			traitsDict at: fm3Class put: aClass allGeneratedTraits.
-
-			elements add: fm3Class ]
+	aClass isTrait
+		ifTrue: [ self processTrait: aClass ifPragmaAbsent: anErrorBlock ]
+		ifFalse: [ aClass metamodelDefinitionPragma
+				ifNil: anErrorBlock
+				ifNotNil: [ :pragma | 
+					| fm3Class |
+					fm3Class := FM3Class named: (pragma argumentAt: 1).
+					superclassDict at: fm3Class put: (pragma argumentAt: 2).
+					fm3Class implementingClass: aClass.
+					(pragma method pragmaAt: #abstract)
+						ifNotNil: [ fm3Class isAbstract: true ].
+					self extractPackageFrom: pragma method for: fm3Class.
+					classDict at: aClass put: fm3Class.
+					(self methodsToProcessFrom: aClass)
+						do: [ :each | self processCompiledMethod: each ].
+					aClass localSlots
+						select: #isFMRelationSlot
+						thenDo: [ :each | self processSlot: each in: aClass ].
+					traitsDict at: fm3Class put: aClass allGeneratedTraits.
+					elements add: fm3Class ] ]
 ]
 
 { #category : #private }
@@ -280,6 +283,26 @@ FMMetaModelBuilder >> processSlot: aSlot in: aClass [
 	aClass compiledMethodAt: aSlot name asSymbol ifPresent: [ :aMethod | self processInfosFrom: aMethod for: prop ].
 
 	elements add: prop
+]
+
+{ #category : #private }
+FMMetaModelBuilder >> processTrait: aTrait ifPragmaAbsent: anErrorBlock [
+	aTrait metamodelDefinitionPragma
+				ifNil: anErrorBlock
+				ifNotNil: [ :pragma | 
+					| fm3Trait |
+					fm3Trait := FM3Trait named: (pragma argumentAt: 1).
+					superclassDict at: fm3Trait put: (pragma argumentAt: 2).
+					fm3Trait implementingClass: aTrait.
+					self extractPackageFrom: pragma method for: fm3Trait.
+					classDict at: aTrait put: fm3Trait.
+					(self methodsToProcessFrom: aTrait)
+						do: [ :each | self processCompiledMethod: each ].
+					aTrait localSlots
+						select: #isFMRelationSlot
+						thenDo: [ :each | self processSlot: each in: aTrait ].
+					traitsDict at: fm3Trait put: aTrait allGeneratedTraits.
+					elements add: fm3Trait ]
 ]
 
 { #category : #accessing }

--- a/src/Fame-Core/FMMetaModelBuilder.class.st
+++ b/src/Fame-Core/FMMetaModelBuilder.class.st
@@ -339,7 +339,7 @@ FMMetaModelBuilder >> resolveObjectReferences [
 	self classes do: [ :meta | metaDict at: meta fullName asString put: meta ].
 
 	"establish class-superclass associations"
-	superclassDict keysAndValuesDo: [ :meta :value | meta superclass: (self ensureClass: value) ].
+	superclassDict keysAndValuesDo: [ :meta :value | meta isFM3Class ifTrue: [ meta superclass: (self ensureClass: value) ] ].
 
 	"establish property-type-opposite relations"
 	typeDict keysAndValuesDo: [ :prop :value | prop type: (self ensureClass: value) ].

--- a/src/Fame-Core/FMModelVisitor.class.st
+++ b/src/Fame-Core/FMModelVisitor.class.st
@@ -54,3 +54,8 @@ FMModelVisitor >> visitPrimitive: aFM3Primitive [
 FMModelVisitor >> visitProperty: aFM3Property [
 	^ self subclassResponsibility
 ]
+
+{ #category : #visiting }
+FMModelVisitor >> visitTrait: aFM3Trait [
+	^ self visitAll: aFM3Trait properties
+]

--- a/src/Fame-Core/Object.extension.st
+++ b/src/Fame-Core/Object.extension.st
@@ -16,6 +16,11 @@ Object >> isFM3Property [
 ]
 
 { #category : #'*Fame-Core' }
+Object >> isFM3Trait [
+	^false
+]
+
+{ #category : #'*Fame-Core' }
 Object >> isMetamodelEntity [
 	^ self class isMetamodelEntity
 ]

--- a/src/Fame-GT/FM3Trait.extension.st
+++ b/src/Fame-GT/FM3Trait.extension.st
@@ -1,0 +1,64 @@
+Extension { #name : #FM3Trait }
+
+{ #category : #'*Fame-GT' }
+FM3Trait >> gtInspectorPropertiesIn: composite [
+	<gtInspectorPresentationOrder: 1>
+	^ composite table
+		title: [ self allPrimitiveProperties size asString , ' Properties' translated ];
+		display: [ self allPrimitiveProperties ];
+		sorted: [ :attribute1 :attribute2 | attribute1 name < attribute2 name ];
+		column: 'name'
+			evaluated: [ :each | each name ]
+			tags: [ :each :aFM3Class | 
+			each mmClass ~= aFM3Class
+				ifTrue: [ each mmClass name ]
+				ifFalse: [ OrderedCollection new ] ];
+		column: 'type' evaluated: [ :each | each gtTypeString ];
+		column: 'derived?' evaluated: [ :each | each isDerived ] width: 50;
+		column: 'Comment' evaluated: #comment;
+		when: [ self allComplexProperties isNotEmpty ];
+		morphicSelectionAct: [ :list | Smalltalk tools browser openOnClass: list selection implementingClass selector: list selection implementingSelector ]
+			icon: GLMUIThemeExtraIcons glamorousBrowse
+			on: $b
+			entitled: 'Browse implementation';
+		morphicSelectionAct: [ :list | list selection inspect ] icon: (self iconNamed: #glamorousInspect) entitled: 'Inspect'
+]
+
+{ #category : #'*Fame-GT' }
+FM3Trait >> gtInspectorRelationsIn: composite [
+	<gtInspectorPresentationOrder: 0>
+	^ composite table
+		title: [ self allComplexProperties size asString , ' Relations' translated ];
+		display: [ self allComplexProperties ];
+		sorted: [ :attribute1 :attribute2 | attribute1 name < attribute2 name ];
+		column: 'name'
+			evaluated: [ :each | each name ]
+			tags: [ :each :aFM3Class | 
+			each mmClass ~= aFM3Class
+				ifTrue: [ each mmClass name ]
+				ifFalse: [ OrderedCollection new ] ];
+		column: 'type' evaluated: [ :each | each gtTypeString ];
+		column: 'opposite'
+			evaluated: [ :each | 
+			each opposite
+				ifNil: [ '' ]
+				ifNotNil: [ :opposite | opposite name ] ];
+		column: 'derived?' evaluated: [ :each | each isDerived ] width: 50;
+		column: 'container?' evaluated: [ :each | each isContainer ] width: 50;
+		column: 'isTarget?' evaluated: [ :each | each isTarget ] width: 50;
+		column: 'isSource?' evaluated: [ :each | each isSource ] width: 50;
+		column: 'Comment' evaluated: #comment;
+		when: [ self allComplexProperties isNotEmpty ];
+		selectionPopulate: #selection
+			on: $o
+			entitled: 'Open opposite'
+			with: [ :list | list selection opposite ];
+		morphicSelectionAct: [ :list | Smalltalk tools browser openOnClass: list selection implementingClass selector: list selection implementingSelector ]
+			icon: GLMUIThemeExtraIcons glamorousBrowse
+			on: $b
+			entitled: 'Browse implementation';
+		morphicSelectionAct: [ :list | list selection inspect ]
+			icon: GLMUIThemeExtraIcons glamorousInspect
+			on: $i
+			entitled: 'Inspect'
+]

--- a/src/Fame-GT/FMMetaModel.extension.st
+++ b/src/Fame-GT/FMMetaModel.extension.st
@@ -16,7 +16,7 @@ FMMetaModel >> gtInspectorClassesIn: composite [
 
 { #category : #'*Fame-GT' }
 FMMetaModel >> gtInspectorHierarchiesIn: composite [
-	<gtInspectorPresentationOrder: 2>
+	<gtInspectorPresentationOrder: 3>
 	^ composite tree
 		title: 'Hierarchies';
 		display: [ (self classes select: [ :each | each superclass = FM3Object instance ]) sorted: [ :x :y | x fullName < y fullName ] ];
@@ -37,7 +37,7 @@ FMMetaModel >> gtInspectorHierarchiesIn: composite [
 
 { #category : #'*Fame-GT' }
 FMMetaModel >> gtInspectorPackagesIn: composite [
-	<gtInspectorPresentationOrder: 1>
+	<gtInspectorPresentationOrder: 2>
 	^ composite fastList
 		title: 'Packages';
 		display: [ self packages sorted: [:x :y | x fullName < y fullName] ];
@@ -59,6 +59,20 @@ FMMetaModel >> gtInspectorPropertiesIn: composite [
 		column: 'Type' evaluated: [ :each | each gtTypeString ];
 		column: 'derived?' evaluated: [ :each | each isDerived ] width: 50;
 		column: 'Comment' evaluated: #comment;
+		morphicSelectionAct: [ :list | list selection implementingClass browse ]
+			icon: GLMUIThemeExtraIcons glamorousBrowse
+			on: $b
+			entitled: 'Browse implementation'
+]
+
+{ #category : #'*Fame-GT' }
+FMMetaModel >> gtInspectorTraitsIn: composite [
+	<gtInspectorPresentationOrder: 1>
+	^ composite fastList
+		title: 'Traits';
+		display: [ self traits sorted: [ :x :y | x fullName < y fullName ] ];
+		format: [ :each | each isAbstract ifTrue: [ Text string: each fullName attribute: TextEmphasis italic ] ifFalse: [ Text fromString: each fullName ] ];
+		tags: [ :each | each package ifNil: [ #() ] ifNotNil: [ each package name ] ];
 		morphicSelectionAct: [ :list | list selection implementingClass browse ]
 			icon: GLMUIThemeExtraIcons glamorousBrowse
 			on: $b

--- a/src/Fame-ImportExport/FMMSEPrinter.class.st
+++ b/src/Fame-ImportExport/FMMSEPrinter.class.st
@@ -36,7 +36,6 @@ FMMSEPrinter >> beginEntity: name [
 
 { #category : #parsing }
 FMMSEPrinter >> beginProperty: name [
-
 	indent := indent + 1.
 	self crTabs.
 	stream 

--- a/src/Fame-ImportExport/FMModelExporter.class.st
+++ b/src/Fame-ImportExport/FMModelExporter.class.st
@@ -63,12 +63,13 @@ FMModelExporter >> export: aCollectionOfElements [
 FMModelExporter >> exportEntity: each [
 	| meta |
 	meta := model metaDescriptionOf: each.
-	printer inEntity: meta fullName do: [ 
-		printer serial: (self indexOf: each).
-		((self sortedPropertiesOf: meta)
-			select: [ :property | 
-			self shouldExportProperty: property for: each ])
-			do:  [ :property | self exportProperty: property for: each ] separatedBy: [ printer printPropertySeparator ] ].
+	printer
+		inEntity: meta fullName
+		do: [ printer serial: (self indexOf: each).
+			((self sortedPropertiesOf: meta)
+				select: [ :property | self shouldExportProperty: property for: each ])
+				do: [ :property | self exportProperty: property for: each ]
+				separatedBy: [ printer printPropertySeparator ] ].
 	self incrementProgressBar
 ]
 
@@ -81,21 +82,22 @@ FMModelExporter >> exportProperty: property for: each [
 
 { #category : #exporting }
 FMModelExporter >> exportProperty: property withAll: values [
-	printer inProperty: property name do: [ 
-		property isMultivalued ifTrue: [ printer beginMultivalue: property ].
-		values
-			do: [ :each | 
-				property type isPrimitive
-					ifTrue: [ printer primitive: each ]
-					ifFalse: [ 
-						property isChildrenProperty
-							ifTrue: [ self exportEntity: each ]
-							ifFalse: [ 
-								(FM3Constant constants includes: each)
-									ifTrue: [ printer referenceName: each name ]
-									ifFalse: [ printer referenceNumber: (self indexOf: each) ] ] ] ]
-			separatedBy: [ printer printEntitySeparator ].
-		property isMultivalued ifTrue: [ printer endMultivalue: property ] ]
+	printer
+		inProperty: property name
+		do: [ property isMultivalued
+				ifTrue: [ printer beginMultivalue: property ].
+			values
+				do: [ :each | 
+					property type isPrimitive
+						ifTrue: [ printer primitive: each ]
+						ifFalse: [ property isChildrenProperty
+								ifTrue: [ self exportEntity: each ]
+								ifFalse: [ (FM3Constant constants includes: each)
+										ifTrue: [ printer referenceName: each name ]
+										ifFalse: [ printer referenceNumber: (self indexOf: each) ] ] ] ]
+				separatedBy: [ printer printEntitySeparator ].
+			property isMultivalued
+				ifTrue: [ printer endMultivalue: property ] ]
 ]
 
 { #category : #exporting }

--- a/src/Fame-Tests/FM3ClassTest.class.st
+++ b/src/Fame-Tests/FM3ClassTest.class.st
@@ -26,7 +26,7 @@ FM3ClassTest >> testAllProperties [
 FM3ClassTest >> testAllPropertiesMoreThanProperties [
 	element := metaMetamodel elementNamed: 'FM3.Class'.
 	self assert: element allProperties size > element properties size.
-	self assert: element allProperties size equals: element properties size + element superclass properties size.
+	self assert: element allProperties size equals: element properties size + element superclass properties size + element superclass superclass properties size.
 	self assert: (element allProperties includesAll: element properties)
 ]
 
@@ -48,7 +48,7 @@ FM3ClassTest >> testAllSuperclasses [
 	element := metaMetamodel elementNamed: 'FM3.Class'.
 	self assert: element allSuperclasses isNotNil.
 	self assert: element allSuperclasses isCollection.
-	self assert: element allSuperclasses size equals: 2
+	self assert: element allSuperclasses size equals: 3
 ]
 
 { #category : #tests }

--- a/src/Fame-Tests/FM3PropertyTest.class.st
+++ b/src/Fame-Tests/FM3PropertyTest.class.st
@@ -19,7 +19,7 @@ FM3PropertyTest >> testClassHasOpposite [
 	| e |
 	e := metaMetamodel elementNamed: 'FM3.Property.class'.
 	self assert: e hasOpposite.
-	self assert: e opposite fullName equals: 'FM3.Class.properties'
+	self assert: e opposite fullName equals: 'FM3.Type.properties'
 ]
 
 { #category : #tests }

--- a/src/Fame-Tests/FMMetaMetaModelTest.class.st
+++ b/src/Fame-Tests/FMMetaMetaModelTest.class.st
@@ -36,7 +36,7 @@ FMMetaMetaModelTest >> testFM3IsComplete [
 	names := metaMetaModel elements collect: [ :each | each fullName ].	"The package"
 	self assert: (names includes: 'FM3').
 	self
-		assert: (metaMetaModel elements detect: [ :el | el fullName = 'FM3.Class.package' ]) opposite
+		assert: (metaMetaModel elements detect: [ :el | el fullName = 'FM3.Type.package' ]) opposite
 		equals: (metaMetaModel elements detect: [ :el | el fullName = 'FM3.Package.classes' ]).
 	"The superclass of everything"	"name, fullName, and owner are the 3 properties that define an element"
 	self assert: (names includes: 'FM3.Element').
@@ -49,10 +49,11 @@ FMMetaMetaModelTest >> testFM3IsComplete [
 	self assert: (names includes: 'FM3.Class.root').
 	self assert: (names includes: 'FM3.Class.superclass').
 	self assert: (names includes: 'FM3.Class.subclasses').
-	self assert: (names includes: 'FM3.Class.traits').
-	self assert: (names includes: 'FM3.Class.package').
-	self assert: (names includes: 'FM3.Class.allProperties').
-	self assert: (names includes: 'FM3.Class.properties').
+	self assert: (names includes: 'FM3.Type').
+	self assert: (names includes: 'FM3.Type.traits').
+	self assert: (names includes: 'FM3.Type.package').
+	self assert: (names includes: 'FM3.Type.allProperties').
+	self assert: (names includes: 'FM3.Type.properties').
 	self assert: (names includes: 'FM3.Property').
 	self assert: (names includes: 'FM3.Property.composite').
 	self assert: (names includes: 'FM3.Property.container').
@@ -65,8 +66,11 @@ FMMetaMetaModelTest >> testFM3IsComplete [
 	self assert: (names includes: 'FM3.Package').
 	self assert: (names includes: 'FM3.Package.extensions').
 	self assert: (names includes: 'FM3.Package.classes').
-	self assert: names size equals: 27.
-	self assert: (names select: [ :n | n beginsWith: 'FM3.' ]) size equals: 26
+	self assert: (names includes: 'FM3.Trait').
+	self assert: (names includes: 'FM3.Trait.primitive').
+	self assert: (names includes: 'FM3.Trait.root').
+	self assert: names size equals: 31.
+	self assert: (names select: [ :n | n beginsWith: 'FM3.' ]) size equals: 30
 ]
 
 { #category : #tests }


### PR DESCRIPTION
This PR introduces Traits as a new concept of the meta-meta-model Fame.

Whereas it can look too much for the meta-meta-model.
I believe it is important to use them.

Indeed, our relations are based on traits and they are not represented in the meta-meta-model.

This PR also should not break any tools already used in the image but only improve support of other tool (for instance, we can use FameJava to generate java meta-model from fame with trait support (java implementation uses interface), without traits, it is not possible).
