### PR TITLE
Add tests for the JSON exporter

### DIFF
--- a/src/Fame-ImportExport/FMJSONParser.class.st
+++ b/src/Fame-ImportExport/FMJSONParser.class.st
@@ -1,3 +1,24 @@
+"
+Description
+--------------------
+
+I am a parser responsible of the JSON syntax parsing. I do not manage the creation of the entities, this part is delegated to a `FMImporter`.
+ 
+Unlike `FMMSEParser`, I do not support parsing properties without value.
+
+Internal Representation and Key Implementation Points.
+--------------------
+
+    Instance Variables
+- buffer:				<aBuffer>				Buffer used to keep a record of the previously read characters during the parsing.
+- characterSet:		<aCharacterSet>		A character set cached to speed up the reading of the JSON.
+- chararacter:			<aCharacter>			The last character read on the stream.
+- importer:				<aFMImporter>		The FMImporter responsible of the management of the entities to be imported.
+- lastUpdate:			<anInteger>			Time in millisecond since the last progress bar update.
+- progBar:				<aProgressBar>		A progress bar to display the parsing progress.
+- stream:				<aStream>				The stream containing the JSON to be read.
+
+"
 Class {
 	#name : #FMJSONParser,
 	#superclass : #FMMSEParser,
@@ -69,10 +90,28 @@ FMJSONParser >> Property [
 	self tPropertyNameOPEN ifFalse: [ ^ self backtrack: pos ].
 	name := self tNAME.
 	self tPropertyNameClose ifFalse: [ ^ self backtrack: pos ].
+	self tPropertyNameSeparator ifFalse: [ ^ self backtrack: pos ].
 	name ifNil: [ ^ self backtrack: pos ].
 	importer inProperty: name do: [ 
 		[ self Value ] whileTrue.
 		self tPropertyValueCLOSE ifFalse: [ ^ self syntaxError ] ].
+	self tWHITESPACE.
+	^ true
+]
+
+{ #category : #tokens }
+FMJSONParser >> Reference [
+	"Matches a Reference node (returns boolean)."
+	"Reference --> OPEN REF n:Identifier { client referenceNumber: n } CLOSE"
+	| position serial |
+	position := self position.
+	self tOPEN ifFalse: [ ^ self backtrack: position ].
+	self tREF ifFalse: [ ^ self backtrack: position ].
+	self tPropertyNameSeparator ifFalse: [ ^ self backtrack: position ].
+	serial := self Identifier.
+	serial ifNil: [ ^ self backtrack: position ].
+	importer referenceNumber: serial.
+	self tCLOSE ifFalse: [ ^ self syntaxError ].
 	self tWHITESPACE.
 	^ true
 ]
@@ -85,6 +124,7 @@ FMJSONParser >> Reference2 [
 	position := self position.
 	self tOPEN ifFalse: [ ^ self backtrack: position ].
 	self tREF ifFalse: [ ^ self backtrack: position ].
+	self tPropertyNameSeparator ifFalse: [ ^ self backtrack: position ].
 	name := self String.
 	name ifNil: [ ^ self backtrack: position ].
 	importer referenceName: name.
@@ -196,7 +236,7 @@ FMJSONParser >> tOPEN [
 
 { #category : #tokens }
 FMJSONParser >> tPropertyNameClose [
-	^ self matchesWord: '":'
+	^ self matchesWord: '"'
 ]
 
 { #category : #tokens }
@@ -223,7 +263,7 @@ FMJSONParser >> tPropertyValueCLOSE [
 FMJSONParser >> tREF [
 	"Matches ref keyword (returns boolean)."
 
-	^ self matchesWord: '"ref":'
+	^ self matchesWord: '"ref"'
 ]
 
 { #category : #tokens }

--- a/src/Fame-ImportExport/FMJSONParser.class.st
+++ b/src/Fame-ImportExport/FMJSONParser.class.st
@@ -100,6 +100,7 @@ FMJSONParser >> Serial [
 	| position serial |
 	position := self position.
 	self tID ifFalse: [ ^ self backtrack: position ].
+	self tPropertyNameSeparator ifFalse: [ ^ self backtrack: position ].
 	serial := self Identifier.
 	serial ifNil: [ ^ self backtrack: position ].
 	importer serial: serial.
@@ -145,7 +146,8 @@ FMJSONParser >> tCLOSE [
 { #category : #tokens }
 FMJSONParser >> tFULLNAME [
 	self tFULLNAMEPropertyOpen ifFalse: [ ^ nil ].
-	
+	self tPropertyNameSeparator ifFalse: [ ^ nil ].
+	self tPropertyNameOPEN ifFalse: [ ^ nil ].
 	buffer reset.
 	[ 
 	buffer nextPut: chararacter.
@@ -167,14 +169,14 @@ FMJSONParser >> tFULLNAMEPropertyClose [
 
 { #category : #tokens }
 FMJSONParser >> tFULLNAMEPropertyOpen [
-	^ self matchesWord: '"FM3":"'
+	^ self matchesWord: '"FM3"'
 ]
 
 { #category : #tokens }
 FMJSONParser >> tID [
 	"Match id keyword (returns boolean)."
 
-	^ self matchesWord: '"id":'
+	^ self matchesWord: '"id"'
 ]
 
 { #category : #tokens }
@@ -200,6 +202,11 @@ FMJSONParser >> tPropertyNameClose [
 { #category : #tokens }
 FMJSONParser >> tPropertyNameOPEN [
 	^ self matchesWord: '"'
+]
+
+{ #category : #tokens }
+FMJSONParser >> tPropertyNameSeparator [
+	^ self matchesWord: ':'
 ]
 
 { #category : #tokens }

--- a/src/Fame-ImportExport/FMModel.extension.st
+++ b/src/Fame-ImportExport/FMModel.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : #FMModel }
 
 { #category : #'*Fame-ImportExport' }
+FMModel >> exportJsonString [
+	| printer |
+	printer := FMJSONPrinter onString.
+	self exportWithPrinter: printer.
+	^ printer stream contents
+]
+
+{ #category : #'*Fame-ImportExport' }
 FMModel >> exportOn: aStream [
 	self exportOn: aStream usingPrinter: FMMSEPrinter
 ]

--- a/src/Fame-Tests/FMDebugImporter.class.st
+++ b/src/Fame-Tests/FMDebugImporter.class.st
@@ -45,6 +45,14 @@ FMDebugImporter >> endProperty: name [
 ]
 
 { #category : #accessing }
+FMDebugImporter >> exportJsonString [
+	| printer |
+	printer := FMJSONPrinter onString.
+	self replayOn: printer.
+	^ printer stream contents
+]
+
+{ #category : #accessing }
 FMDebugImporter >> exportString [
 	| printer |
 	printer := FMMSEPrinter onString.

--- a/src/Fame-Tests/FMJSONParserTest.class.st
+++ b/src/Fame-Tests/FMJSONParserTest.class.st
@@ -992,3 +992,140 @@ FMJSONParserTest >> testPropertyWithReferences [
 	self assert: r contents equals: a.
 	self assert: p atEnd
 ]
+
+{ #category : #tests }
+FMJSONParserTest >> testPropertyWithStrings2 [
+	a := #(#(#beginProperty: 'name') #(#primitive: 'bar"ba"rossa') #(#endProperty: 'name')).
+	r reset.
+	p fromString: '"name":"bar\"ba\"rossa"'.
+	p Property.
+	self assert: r contents equals: a.
+	self assert: p atEnd.
+	r reset.
+	p fromString: '"name"  :   "bar\"ba\"rossa"  '.
+	p Property.
+	self assert: r contents equals: a.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testSerial [
+	p fromString: '"id":42'.
+	p Serial.
+	self assert: r contents equals: #(#(#serial: 42)).
+	self assert: p atEnd.
+	self setUp.
+	p fromString: '"id" :  42 '.
+	p Serial.
+	self assert: r contents equals: #(#(#serial: 42)).
+	self assert: p atEnd.
+	self setUp
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testSimpleDocument [
+	p fromString: '[]'.
+	p Document.
+	self assert: r contents equals: #(#(#beginDocument) #(#endDocument)).
+	self assert: p atEnd.
+	r reset.
+	p fromString: '  [  ]   '.
+	p Document.
+	self assert: r contents equals: #(#(#beginDocument) #(#endDocument)).
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testValueFloat [
+	r reset.
+	p fromString: '3.14'.
+	p Value.
+	self assert: r contents equals: #(#(#primitive: 3.14)).
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testValueFloatError [
+	r reset.
+	p fromString: '3.14e$'.
+	self should: [ p Value ] raise: FMSyntaxError
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testValueFloatError2 [
+	r reset.
+	p fromString: '1..2'.
+	self should: [ p Value ] raise: FMSyntaxError
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testValueFloatWithExponent [
+	r reset.
+	p fromString: '1.291e3'.
+	p Value.
+	self assert: r contents equals: #(#(#primitive: 1291)).
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testValueNegativeNumber [
+	r reset.
+	p fromString: '-42'.
+	p Value.
+	self assert: r contents equals: #(#(#primitive: -42)).
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testValueNegativeNumberError [
+	r reset.
+	p fromString: '--42'.
+	p Value.
+	self assertEmpty: r contents.
+	self assert: p position equals: 1
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testValueNumber [
+	r reset.
+	p fromString: '13'.
+	p Value.
+	self assert: r contents equals: #(#(#primitive: 13)).
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testValueReference [
+	r reset.
+	p fromString: '{"ref": 24}'.
+	p Value.
+	self assert: r contents equals: #(#(#referenceNumber: 24)).
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testValueReferenceBigInteger [
+	r reset.
+	p fromString: '{"ref": 112233445566778899}'.
+	p Value.
+	self assert: r contents equals: #(#(#referenceNumber: 112233445566778899)).
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testValueReferenceFullName [
+	r reset.
+	p fromString: '{"ref": "EG.Foo"}'.
+	p Value.
+	self assert: r contents equals: #(#(#referenceName: 'EG.Foo')).
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testValueReferenceName [
+	r reset.
+	p fromString: '{"ref": "Foo"}'.
+	p Value.
+	self assert: r contents equals: #(#(#referenceName: 'Foo')).
+	self assert: p atEnd
+]

--- a/src/Fame-Tests/FMJSONParserTest.class.st
+++ b/src/Fame-Tests/FMJSONParserTest.class.st
@@ -727,6 +727,36 @@ FMJSONParserTest >> testEntityWithID [
 ]
 
 { #category : #tests }
+FMJSONParserTest >> testEntityWithProperties [
+	a := #(#(#beginEntity: 'Foo') #(#beginProperty: 'name') #(#primitive: 'test') #(#endProperty: 'name') #(#beginProperty: 'count') #(#primitive: 12) #(#endProperty: 'count') #(#endEntity: 'Foo')).
+	r reset.
+	p fromString: '{"FM3":"Foo","name":"test","count":12}'.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd.
+	r reset.
+	p fromString: '{ "FM3" : "Foo" , "name" : "test" , "count" : 12 } '.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testEntityWithPropertiesAndID [
+	a := #(#(#beginEntity: 'Foo') #(#serial: 42) #(#beginProperty: 'name') #(#primitive: 'test') #(#endProperty: 'name') #(#beginProperty: 'count') #(#primitive: 12) #(#endProperty: 'count') #(#endEntity: 'Foo')).
+	r reset.
+	p fromString: '{"FM3":"Foo","id":42,"name":"test","count":12}'.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd.
+	r reset.
+	p fromString: '{ "FM3" : "Foo" , "id" : 42 , "name" : "test" , "count" : 12 } '.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
 FMJSONParserTest >> testFamixModel [
 	| metamodel names famixPackage accessClass accessorProperty behaviouralEntity outgoingAccesses |
 	metamodel := FMMetaModel fromJSONString: self class famix30mse.
@@ -801,6 +831,47 @@ FMJSONParserTest >> testFamixModel [
 ]
 
 { #category : #tests }
+FMJSONParserTest >> testFullName [
+	p fromString: '"FM3":"Foo"'.
+	r := p tFULLNAME.
+	self assert: r equals: 'Foo'.
+	self assert: p atEnd.
+	p fromString: '"FM3" : "A" '.
+	r := p tFULLNAME.
+	self assert: r equals: 'A'.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testFullName2 [
+	p fromString: '"FM3":"Foo.Bar"'.
+	r := p tFULLNAME.
+	self assert: r equals: 'Foo.Bar'.
+	self assert: p atEnd.
+	p fromString: '"FM3" : "A.b" '.
+	r := p tFULLNAME.
+	self assert: r equals: 'A.b'.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testFullName3 [
+	p fromString: '"FM3":"Foo.Bar.Qux"'.
+	r := p tFULLNAME.
+	self assert: r equals: 'Foo.Bar.Qux'.
+	self assert: p atEnd.
+	p fromString: '"FM3" : "A.b.q" '.
+	r := p tFULLNAME.
+	self assert: r equals: 'A.b.q'.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testImporter [
+	self assert: p importer equals: r
+]
+
+{ #category : #tests }
 FMJSONParserTest >> testMatchString [
 	p fromString: '"Lorem"'.
 	r := p String.
@@ -813,5 +884,111 @@ FMJSONParserTest >> testMatchString [
 	p fromString: '"Eo\"ipso"'.
 	r := p String.
 	self assert: r equals: 'Eo"ipso'.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testNumber [
+	p fromString: '14'.
+	r := p Number.
+	self assert: r equals: 14.
+	self assert: p atEnd.
+	p fromString: '-23x'.
+	r := p Number.
+	self assert: r equals: -23.
+	self assert: p peek equals: $x.
+	p fromString: '1'.
+	r := p Number.
+	self assert: r equals: 1.
+	self assert: p atEnd.
+	p fromString: '-1'.
+	r := p Number.
+	self assert: r equals: -1.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testNumber2 [
+	p fromString: '12.91'.
+	r := p Number.
+	self assert: p atEnd.
+	self assert: r equals: 12.91.
+	p fromString: '-47.11'.
+	r := p Number.
+	self assert: r equals: -47.11.
+	self assert: p atEnd.
+	p fromString: '1.1'.
+	r := p Number.
+	self assert: r equals: 1.1.
+	self assert: p atEnd.
+	p fromString: '-1.1'.
+	r := p Number.
+	self assert: r equals: -1.1.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testNumber3 [
+	p fromString: '12.91e33'.
+	r := p Number.
+	self assert: p atEnd.
+	self assert: r equals: 1.291e34.
+	p fromString: '-47.11e22'.
+	r := p Number.
+	self assert: r equals: -4.711e23.
+	self assert: p atEnd.
+	p fromString: '-23.11e-15'.
+	r := p Number.
+	self assert: r equals: -2.311e-14.
+	self assert: p atEnd.
+	p fromString: '1.1e2'.
+	r := p Number.
+	self assert: r equals: 110.0.
+	self assert: p atEnd.
+	p fromString: '-1.1e2'.
+	r := p Number.
+	self assert: r equals: -110.0.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testNumberTrailingDotFails [
+	p fromString: '12.'.
+	self should: [ p Number ] raise: Error
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testNumberTrailingLetterFails [
+	p fromString: '12.11e'.
+	self should: [ p Number ] raise: Error
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testProperty [
+	a := #(#(#beginProperty: 'name') #(#primitive: true) #(#endProperty: 'name')).
+	r reset.
+	p fromString: '"name":true'.
+	p Property.
+	self assert: r contents equals: a.
+	self assert: p atEnd.
+	r reset.
+	p fromString: '"name"  :  true  '.
+	p Property.
+	self assert: r contents equals: a.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testPropertyWithReferences [
+	a := #(#(#beginProperty: 'name') #(#referenceNumber: 2) #(#endProperty: 'name')).
+	r reset.
+	p fromString: '"name":{"ref":2}'.
+	p Property.
+	self assert: r contents equals: a.
+	self assert: p atEnd.
+	r reset.
+	p fromString: '"name"  :  {  "ref"  :  2  }  '.
+	p Property.
+	self assert: r contents equals: a.
 	self assert: p atEnd
 ]

--- a/src/Fame-Tests/FMJSONParserTest.class.st
+++ b/src/Fame-Tests/FMJSONParserTest.class.st
@@ -663,6 +663,70 @@ FMJSONParserTest >> setUp [
 ]
 
 { #category : #tests }
+FMJSONParserTest >> testBacktrack [
+	| pos |
+	p fromString: 'abcdefg'.
+	self assert: p peek equals: $a.
+	self assert: p next equals: $b.
+	pos := p position.
+	self assert: p peek equals: $b.
+	self assert: p next equals: $c.
+	self assert: p next equals: $d.
+	self assert: p next equals: $e.
+	p backtrack: pos.
+	self assert: p peek equals: $b.
+	self assert: p next equals: $c.
+	self assert: p next equals: $d.
+	self assert: p next equals: $e
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testEmptyDocument [
+	p fromString: ''.
+	p Document.
+	self assert: r contents equals: #(#(#beginDocument) #(#endDocument)).
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testEmptyExportString [
+	p fromString: ''.
+	p Document.
+	self assert: r exportJsonString equals: '[
+]'
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testEntity [
+	a := #(#(#beginEntity: 'Foo') #(#endEntity: 'Foo')).
+	r reset.
+	p fromString: '{"FM3":"Foo"}'.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd.
+	r reset.
+	p fromString: '{ "FM3" : "Foo" }  '.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testEntityWithID [
+	a := #(#(#beginEntity: 'Foo') #(#serial: 42) #(#endEntity: 'Foo')).
+	r reset.
+	p fromString: '{"FM3":"Foo","id":42}'.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd.
+	r reset.
+	p fromString: '{  "FM3"   :   "Foo"   ,   "id"   :   42   }  '.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
 FMJSONParserTest >> testFamixModel [
 	| metamodel names famixPackage accessClass accessorProperty behaviouralEntity outgoingAccesses |
 	metamodel := FMMetaModel fromJSONString: self class famix30mse.


### PR DESCRIPTION
This idea was to take most of the MSE parser tests and add them for the JSON exporter.