### PR TITLE
Add spec2extension

### DIFF
--- a/src/BaselineOfFame/BaselineOfFame.class.st
+++ b/src/BaselineOfFame/BaselineOfFame.class.st
@@ -9,33 +9,35 @@ Class {
 
 { #category : #baseline }
 BaselineOfFame >> baseline: spec [
+
 	<baseline>
-	spec
-		for: #common
-		do: [ "Dependencies"
-			self
-				hashtable: spec;
-				mocketry: spec;
-				pharoBackwardCompatibility: spec;
-				iterators: spec;
-				treeQuery: spec.
+	spec for: #common do: [ "Dependencies"
+		self
+			hashtable: spec;
+			mocketry: spec;
+			pharoBackwardCompatibility: spec;
+			iterators: spec;
+			treeQuery: spec.
 
-			"Packages"
-			spec
-				package: 'Fame-Core' with: [ spec requires: #('Hashtable' 'TreeQuery' 'Iterators' 'PharoBackwardCompatibility') ];
-				package: 'Fame-Rules';
-				package: 'Fame-ImportExport' with: [ spec requires: #('Fame-Core') ];
-				package: 'Fame-Example';
-				package: 'Fame-Tests' with: [ spec requires: #('Fame-Core' 'Fame-ImportExport' 'Fame-Example' 'Mocketry') ];
-				package: 'Fame-GT' with: [ spec requires: #('Fame-ImportExport') ];
-				package: 'Fame-Deprecated' with: [ spec requires: #('Fame-ImportExport') ].
+		"Packages"
+		spec
+			package: 'Fame-Core' with: [ spec requires: #( 'Hashtable' 'TreeQuery' 'Iterators' 'PharoBackwardCompatibility' ) ];
+			package: 'Fame-Rules';
+			package: 'Fame-ImportExport' with: [ spec requires: #( 'Fame-Core' ) ];
+			package: 'Fame-Example';
+			package: 'Fame-Tests' with: [ spec requires: #( 'Fame-Core' 'Fame-ImportExport' 'Fame-Example' 'Mocketry' ) ];
+			package: 'Fame-GT' with: [ spec requires: #( 'Fame-ImportExport' ) ];
+			package: 'Fame-Deprecated' with: [ spec requires: #( 'Fame-ImportExport' ) ].
 
-			"Groups"
-			spec
-				group: 'Core' with: #('Fame-Core' 'Fame-ImportExport' 'Fame-Rules');
-				group: 'GT' with: #('Core' 'Fame-GT');
-				group: 'Deprecated' with: #('Core' 'Fame-Deprecated');
-				group: 'Tests' with: #('Fame-Tests') ]
+		spec for: #( #'pharo6.x' #'pharo7.x' #'pharo8.x' ) do: [ spec package: 'Fame-GT' with: [ spec requires: #( 'Fame-ImportExport' ) ] ].
+		spec for: #( #'pharo9.x' ) do: [ spec package: 'Fame-Spec2' ].
+
+		"Groups"
+		spec
+			group: 'Core' with: #( 'Fame-Core' 'Fame-ImportExport' 'Fame-Rules' );
+			group: 'GT' with: #( 'Core' 'Fame-GT' );
+			group: 'Deprecated' with: #( 'Core' 'Fame-Deprecated' );
+			group: 'Tests' with: #( 'Fame-Tests' ) ]
 ]
 
 { #category : #dependencies }

--- a/src/BaselineOfFame/BaselineOfFame.class.st
+++ b/src/BaselineOfFame/BaselineOfFame.class.st
@@ -26,7 +26,6 @@ BaselineOfFame >> baseline: spec [
 			package: 'Fame-ImportExport' with: [ spec requires: #( 'Fame-Core' ) ];
 			package: 'Fame-Example';
 			package: 'Fame-Tests' with: [ spec requires: #( 'Fame-Core' 'Fame-ImportExport' 'Fame-Example' 'Mocketry' ) ];
-			package: 'Fame-GT' with: [ spec requires: #( 'Fame-ImportExport' ) ];
 			package: 'Fame-Deprecated' with: [ spec requires: #( 'Fame-ImportExport' ) ].
 
 		spec for: #( #'pharo6.x' #'pharo7.x' #'pharo8.x' ) do: [ spec package: 'Fame-GT' with: [ spec requires: #( 'Fame-ImportExport' ) ] ].
@@ -35,7 +34,6 @@ BaselineOfFame >> baseline: spec [
 		"Groups"
 		spec
 			group: 'Core' with: #( 'Fame-Core' 'Fame-ImportExport' 'Fame-Rules' );
-			group: 'GT' with: #( 'Core' 'Fame-GT' );
 			group: 'Deprecated' with: #( 'Core' 'Fame-Deprecated' );
 			group: 'Tests' with: #( 'Fame-Tests' ) ]
 ]

--- a/src/Fame-Spec2/FM3Class.extension.st
+++ b/src/Fame-Spec2/FM3Class.extension.st
@@ -1,0 +1,30 @@
+Extension { #name : #FM3Class }
+
+{ #category : #'*Fame-Spec2' }
+FM3Class >> stFmInspectorProperties: aBuilder [
+
+	<inspectorPresentationOrder: 1 title: 'Properties'>
+	^ aBuilder newTable
+		  addColumn: (SpStringTableColumn title: 'Name' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each fullName ]) beSortable;
+		  addColumn: (SpStringTableColumn title: 'Type' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each stFmTypeString ]);
+		  addColumn: (SpStringTableColumn title: 'Derived?' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each isDerived ]);
+		  addColumn: (SpStringTableColumn title: 'Comment' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each comment ]);
+		  items: self allPrimitiveProperties;
+		  yourself
+]
+
+{ #category : #'*Fame-Spec2' }
+FM3Class >> stFmInspectorRelations: aBuilder [
+
+	<inspectorPresentationOrder: 0 title: 'Relations'>
+	^ aBuilder newTable
+		  addColumn: (SpStringTableColumn title: 'Name' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each fullName ]) beSortable;
+		  addColumn: (SpStringTableColumn title: 'Type' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each stFmTypeString ]);
+		  addColumn: (SpStringTableColumn title: 'Derived?' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each isDerived ]);
+		  addColumn: (SpStringTableColumn title: 'Container?' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each isContainer ]);
+		  addColumn: (SpStringTableColumn title: 'isTarget?' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each isTarget ]);
+		  addColumn: (SpStringTableColumn title: 'isSource?' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each isSource ]);
+		  addColumn: (SpStringTableColumn title: 'Comment' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each comment ]);
+		  items: self allComplexProperties;
+		  yourself
+]

--- a/src/Fame-Spec2/FM3Package.extension.st
+++ b/src/Fame-Spec2/FM3Package.extension.st
@@ -1,0 +1,21 @@
+Extension { #name : #FM3Package }
+
+{ #category : #'*Fame-Spec2' }
+FM3Package >> stFmInspectorClasses: aBuilder [
+
+	<inspectorPresentationOrder: 0 title: 'Classes'>
+	^ aBuilder newTable
+		  addColumn: (SpStringTableColumn title: 'Class' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each fullName ]) beSortable;
+		  items: self classes asOrderedCollection ;
+		  yourself
+]
+
+{ #category : #'*Fame-Spec2' }
+FM3Package >> stFmInspectorExtensions: aBuilder [
+
+	<inspectorPresentationOrder: 0 title: 'Extensions'>
+	^ aBuilder newTable
+		  addColumn: (SpStringTableColumn title: 'Extensions' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each fullName ]) beSortable;
+		  items: self extensions asOrderedCollection;
+		  yourself
+]

--- a/src/Fame-Spec2/FM3Property.extension.st
+++ b/src/Fame-Spec2/FM3Property.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #FM3Property }
+
+{ #category : #'*Fame-Spec2' }
+FM3Property >> stFmTypeString [
+	^ String
+		streamContents: [ :s | 
+			self type ifNotNil: [ :t | s nextPutAll: t name ].
+			self isMultivalued ifTrue: [ s nextPutAll: ' *' ].
+			self isDerived ifTrue: [ s nextPutAll: ' /' ] ]
+]

--- a/src/Fame-Spec2/FM3Trait.extension.st
+++ b/src/Fame-Spec2/FM3Trait.extension.st
@@ -1,0 +1,30 @@
+Extension { #name : #FM3Trait }
+
+{ #category : #'*Fame-Spec2' }
+FM3Trait >> stFmInspectorProperties: aBuilder [
+
+	<inspectorPresentationOrder: 1 title: 'Properties'>
+	^ aBuilder newTable
+		  addColumn: (SpStringTableColumn title: 'Name' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each fullName ]) beSortable;
+		  addColumn: (SpStringTableColumn title: 'Type' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each stFmTypeString ]);
+		  addColumn: (SpStringTableColumn title: 'Derived?' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each isDerived ]);
+		  addColumn: (SpStringTableColumn title: 'Comment' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each comment ]);
+		  items: self allPrimitiveProperties;
+		  yourself
+]
+
+{ #category : #'*Fame-Spec2' }
+FM3Trait >> stFmInspectorRelations: aBuilder [
+
+	<inspectorPresentationOrder: 0 title: 'Relations'>
+	^ aBuilder newTable
+		  addColumn: (SpStringTableColumn title: 'Name' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each fullName ]) beSortable;
+		  addColumn: (SpStringTableColumn title: 'Type' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each stFmTypeString ]);
+		  addColumn: (SpStringTableColumn title: 'Derived?' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each isDerived ]);
+		  addColumn: (SpStringTableColumn title: 'Container?' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each isContainer ]);
+		  addColumn: (SpStringTableColumn title: 'isTarget?' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each isTarget ]);
+		  addColumn: (SpStringTableColumn title: 'isSource?' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each isSource ]);
+		  addColumn: (SpStringTableColumn title: 'Comment' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each comment ]);
+		  items: self allComplexProperties;
+		  yourself
+]

--- a/src/Fame-Spec2/FMMetaModel.extension.st
+++ b/src/Fame-Spec2/FMMetaModel.extension.st
@@ -1,0 +1,54 @@
+Extension { #name : #FMMetaModel }
+
+{ #category : #'*Fame-Spec2' }
+FMMetaModel >> stFmInspectorClasses: aBuilder [
+
+	<inspectorPresentationOrder: 0 title: 'Classes'>
+	^ aBuilder newTable
+		  addColumn: (SpStringTableColumn title: 'Class' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each fullName ]) beSortable;
+		  items: self classes;
+		  yourself
+]
+
+{ #category : #'*Fame-Spec2' }
+FMMetaModel >> stFmInspectorHierarchies: aBuilder [
+
+	<inspectorPresentationOrder: 3 title: 'Hierarchies'>
+	1 h.
+	^ aBuilder newTree
+		  roots: self packages;
+		  yourself
+]
+
+{ #category : #'*Fame-Spec2' }
+FMMetaModel >> stFmInspectorPackages: aBuilder [
+
+	<inspectorPresentationOrder: 2 title: 'Packages'>
+	^ aBuilder newTable
+		  addColumn: (SpStringTableColumn title: 'Package' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each fullName ]) beSortable;
+		  items: self packages;
+		  yourself
+]
+
+{ #category : #'*Fame-Spec2' }
+FMMetaModel >> stFmInspectorProperties: aBuilder [
+
+	<inspectorPresentationOrder: 5 title: 'Properties'>
+	^ aBuilder newTable
+		  addColumn: (SpStringTableColumn title: 'Name' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each fullName ]) beSortable;
+		  addColumn: (SpStringTableColumn title: 'Type' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each stFmTypeString ]);
+		  addColumn: (SpStringTableColumn title: 'Derived?' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each isDerived ]);
+		  addColumn: (SpStringTableColumn title: 'Comment' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each comment ]);
+		  items: self properties;
+		  yourself
+]
+
+{ #category : #'*Fame-Spec2' }
+FMMetaModel >> stFmInspectorTraits: aBuilder [
+
+	<inspectorPresentationOrder: 1 title: 'Traits'>
+	^ aBuilder newTable
+		  addColumn: (SpStringTableColumn title: 'Trait' evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each fullName ]) beSortable;
+		  items: self traits;
+		  yourself
+]

--- a/src/Fame-Spec2/FMMetaModel.extension.st
+++ b/src/Fame-Spec2/FMMetaModel.extension.st
@@ -14,9 +14,13 @@ FMMetaModel >> stFmInspectorClasses: aBuilder [
 FMMetaModel >> stFmInspectorHierarchies: aBuilder [
 
 	<inspectorPresentationOrder: 3 title: 'Hierarchies'>
-	1 h.
 	^ aBuilder newTree
-		  roots: self packages;
+		  roots: (self classes select: [ :each | each superclass = FM3Object instance ]);
+		  children: [ :c | c subclasses ];
+		  display: [ :each | 
+			  each isAbstract
+				  ifTrue: [ Text string: each fullName attribute: TextEmphasis italic ]
+				  ifFalse: [ Text fromString: each fullName ] ];
 		  yourself
 ]
 

--- a/src/Fame-Spec2/package.st
+++ b/src/Fame-Spec2/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Fame-Spec2' }


### PR DESCRIPTION
This PR removes the GT extension package from P9 and adds a Spec2 extension package since P9.
It aims to port the Fame UI in P9 (where spec2 replace GT)