### PR TITLE
Add support for default values

### DIFF
--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -160,7 +160,7 @@ FM3Class >> initialize [
 
 { #category : #testing }
 FM3Class >> isAbstract [
-	<FMProperty: #abstract type: #Boolean>
+	<FMProperty: #abstract type: #Boolean defaultValue: false>
 	^ isAbstract
 ]
 
@@ -186,14 +186,14 @@ FM3Class >> isFM3Class [
 
 { #category : #testing }
 FM3Class >> isPrimitive [
-	<FMProperty: #primitive type: #Boolean>
+	<FMProperty: #primitive type: #Boolean defaultValue: false>
 	<derived>
 	^ false
 ]
 
 { #category : #testing }
 FM3Class >> isRoot [
-	<FMProperty: #root type: #Boolean>
+	<FMProperty: #root type: #Boolean defaultValue: false>
 	<derived>
 	^ false
 ]

--- a/src/Fame-Core/FM3Property.class.st
+++ b/src/Fame-Core/FM3Property.class.st
@@ -91,7 +91,7 @@ FM3Property >> compiledMethod [
 
 { #category : #private }
 FM3Property >> defaultValue [
-	<FMProperty: #defaultValue type: #Object >
+	<FMProperty: #defaultValue type: #Object>
 	"The type of this property should be FM3Primitive or something else, but it's currently impossible to reference abstract classes"
 	^ defaultValue 
 ]

--- a/src/Fame-Core/FM3Property.class.st
+++ b/src/Fame-Core/FM3Property.class.st
@@ -173,7 +173,7 @@ FM3Property >> isChildrenProperty [
 
 { #category : #accessing }
 FM3Property >> isContainer [
-	<FMProperty: #container type: #Boolean>
+	<FMProperty: #container type: #Boolean defaultValue: false>
 	^isContainer
 ]
 

--- a/src/Fame-Core/FM3Property.class.st
+++ b/src/Fame-Core/FM3Property.class.st
@@ -61,7 +61,8 @@ Class {
 		'implementingSelector',
 		'isTarget',
 		'isSource',
-		'comment'
+		'comment',
+		'defaultValue'
 	],
 	#category : #'Fame-Core-Model'
 }
@@ -86,6 +87,18 @@ FM3Property >> comment: anObject [
 { #category : #accessing }
 FM3Property >> compiledMethod [
 	^ self mmClass ifNotNil: [ :aClass | aClass implementingClass >> self implementingSelector ]
+]
+
+{ #category : #private }
+FM3Property >> defaultValue [
+	<FMProperty: #defaultValue type: #Object >
+	"The type of this property should be FM3Primitive or something else, but it's currently impossible to reference abstract classes"
+	^ defaultValue 
+]
+
+{ #category : #private }
+FM3Property >> defaultValue: aValue [
+	defaultValue := aValue
 ]
 
 { #category : #private }

--- a/src/Fame-Core/FM3Property.class.st
+++ b/src/Fame-Core/FM3Property.class.st
@@ -184,7 +184,7 @@ FM3Property >> isContainer: anObject [
 
 { #category : #accessing }
 FM3Property >> isDerived [
-	<FMProperty: #derived type: #Boolean>
+	<FMProperty: #derived type: #Boolean defaultValue: false>
 	^isDerived
 ]
 
@@ -205,7 +205,7 @@ FM3Property >> isFM3Property [
 
 { #category : #accessing }
 FM3Property >> isMultivalued [
-	<FMProperty: #multivalued type: #Boolean>
+	<FMProperty: #multivalued type: #Boolean defaultValue: false>
 	^isMultivalued
 ]
 

--- a/src/Fame-Core/FM3Property.class.st
+++ b/src/Fame-Core/FM3Property.class.st
@@ -120,6 +120,12 @@ FM3Property >> getRawFrom: element [
 	^ element perform: self implementingSelector
 ]
 
+{ #category : #private }
+FM3Property >> hasDefaultValue [
+	^ defaultValue isNotNil 
+	
+]
+
 { #category : #testing }
 FM3Property >> hasImplementingSelector [
 	^ self implementingSelector isNotNil

--- a/src/Fame-Core/FM3Trait.class.st
+++ b/src/Fame-Core/FM3Trait.class.st
@@ -107,14 +107,14 @@ FM3Trait >> isFM3Trait [
 
 { #category : #testing }
 FM3Trait >> isPrimitive [
-	<FMProperty: #primitive type: #Boolean>
+	<FMProperty: #primitive type: #Boolean defaultValue: false>
 	<derived>
 	^ false
 ]
 
 { #category : #testing }
 FM3Trait >> isRoot [
-	<FMProperty: #root type: #Boolean>
+	<FMProperty: #root type: #Boolean defaultValue: false>
 	<derived>
 	^ false
 ]

--- a/src/Fame-Core/FMMetaModelBuilder.class.st
+++ b/src/Fame-Core/FMMetaModelBuilder.class.st
@@ -241,12 +241,14 @@ FMMetaModelBuilder >> processCompiledMethod: aMethod [
 
 	"29 of October 2019: The MSEProperty:type:(opposite:) pragma is deprecated and should not be used anymore. But we still keep it for some time for backward compatibility."
 	method pragmas
-		detect: [ :each | #(#MSEProperty:type:opposite: #MSEProperty:type: #FMProperty:type:opposite: #FMProperty:type:) includes: each selector ]
+		detect: [ :each | #(#MSEProperty:type:opposite: #MSEProperty:type: #FMProperty:type:opposite: #FMProperty:type: #FMProperty:type:defaultValue:) includes: each selector ]
 		ifFound: [ :pragma | 
 			| prop |
 			prop := FM3Property named: (pragma argumentAt: 1) asString.
 			typeDict at: prop put: (pragma argumentAt: 2).
 			mmClassDict at: prop put: method methodClass.
+			(pragma selector = #FMProperty:type:defaultValue:)
+				ifTrue: [ prop defaultValue: (pragma argumentAt: 3) ].
 			(pragma selector = #MSEProperty:type:opposite: or: [ pragma selector = #FMProperty:type:opposite: ])
 				ifTrue: [ oppositeDict at: prop put: (pragma argumentAt: 3) ].
 			self processInfosFrom: method for: prop.

--- a/src/Fame-Core/FMProperty.class.st
+++ b/src/Fame-Core/FMProperty.class.st
@@ -16,10 +16,36 @@ Examples
 Class {
 	#name : #FMProperty,
 	#superclass : #InstanceVariableSlot,
+	#instVars : [
+		'defaultValue'
+	],
 	#category : #'Fame-Core-Utilities'
 }
 
 { #category : #testing }
+FMProperty >> defaultValue [
+	^ defaultValue 
+]
+
+{ #category : #testing }
+FMProperty >> defaultValue: aValue [
+	defaultValue := aValue
+]
+
+{ #category : #testing }
 FMProperty >> isFameSlot [
 	^ true
+]
+
+{ #category : #testing }
+FMProperty >> printOn: aStream [
+
+	aStream
+		store: self name;
+		nextPutAll: ' => ';
+		nextPutAll: self class name.
+	self defaultValue ifNotNil: [ 
+		aStream
+			nextPutAll: ' defaultValue: ';
+			store: self defaultValue ]
 ]

--- a/src/Fame-Tests/FMMetaMetaModelTest.class.st
+++ b/src/Fame-Tests/FMMetaMetaModelTest.class.st
@@ -11,7 +11,7 @@ Class {
 FMMetaMetaModelTest >> assertDefaultValueFor: fullName is: aValue [
 	| method pragma defaultValue prop implementingSelector implementingClass |
 	
-	prop := (metaMetaModel elements select: [ :each | each fullName = fullName ]) at: 1.
+	prop := self findProperty: fullName.
 	
 	implementingSelector := prop implementingSelector.
 	implementingClass := prop mmClass implementingClass.
@@ -28,6 +28,11 @@ FMMetaMetaModelTest >> assertDefaultValueFor: fullName is: aValue [
 	self assert: prop defaultValue equals: defaultValue.
 	self assert: prop defaultValue equals: aValue.
 	self assert: defaultValue equals: aValue.
+]
+
+{ #category : #tests }
+FMMetaMetaModelTest >> findProperty: fullName [
+	^ (metaMetaModel elements select: [ :each | each fullName = fullName ]) at: 1.
 ]
 
 { #category : #running }
@@ -62,7 +67,7 @@ FMMetaMetaModelTest >> testFM3DefaultValue [
 	self assertDefaultValueFor: 'FM3.Trait.primitive' is: false.
 	self assertDefaultValueFor: 'FM3.Trait.root' is: false.
 
-	
+	self assert: (self findProperty: 'FM3.Element.fullName') defaultValue equals: nil.
 ]
 
 { #category : #tests }

--- a/src/Fame-Tests/FMMetaMetaModelTest.class.st
+++ b/src/Fame-Tests/FMMetaMetaModelTest.class.st
@@ -33,7 +33,8 @@ FMMetaMetaModelTest >> assertDefaultValueFor: fullName is: aValue [
 { #category : #running }
 FMMetaMetaModelTest >> setUp [
 	super setUp.
-	metaMetaModel := FMMetaMetaModel default
+	metaMetaModel := FMMetaMetaModel default.
+	metaMetaModel class reset.
 ]
 
 { #category : #tests }
@@ -53,6 +54,13 @@ FMMetaMetaModelTest >> testFM3Classes [
 { #category : #tests }
 FMMetaMetaModelTest >> testFM3DefaultValue [
 	self assertDefaultValueFor: 'FM3.Property.container' is: false.
+	self assertDefaultValueFor: 'FM3.Property.derived' is: false.
+	self assertDefaultValueFor: 'FM3.Property.multivalued' is: false.
+	self assertDefaultValueFor: 'FM3.Class.abstract' is: false.
+	self assertDefaultValueFor: 'FM3.Class.root' is: false.
+	self assertDefaultValueFor: 'FM3.Class.primitive' is: false.
+	self assertDefaultValueFor: 'FM3.Trait.primitive' is: false.
+	self assertDefaultValueFor: 'FM3.Trait.root' is: false.
 
 	
 ]

--- a/src/Fame-Tests/FMMetaMetaModelTest.class.st
+++ b/src/Fame-Tests/FMMetaMetaModelTest.class.st
@@ -12,6 +12,7 @@ FMMetaMetaModelTest >> assertDefaultValueFor: fullName is: aValue [
 	| method pragma defaultValue prop implementingSelector implementingClass |
 	
 	prop := self findProperty: fullName.
+	self assert: prop hasDefaultValue.
 	
 	implementingSelector := prop implementingSelector.
 	implementingClass := prop mmClass implementingClass.

--- a/src/Fame-Tests/FMMetaMetaModelTest.class.st
+++ b/src/Fame-Tests/FMMetaMetaModelTest.class.st
@@ -7,6 +7,29 @@ Class {
 	#category : #'Fame-Tests-Core'
 }
 
+{ #category : #tests }
+FMMetaMetaModelTest >> assertDefaultValueFor: fullName is: aValue [
+	| method pragma defaultValue prop implementingSelector implementingClass |
+	
+	prop := (metaMetaModel elements select: [ :each | each fullName = fullName ]) at: 1.
+	
+	implementingSelector := prop implementingSelector.
+	implementingClass := prop mmClass implementingClass.
+	method := implementingClass lookupSelector: implementingSelector.
+	
+	self assert: method pragmas isNotEmpty.
+	
+	pragma := method pragmas at: 1.
+	self assert: pragma selector equals: #FMProperty:type:defaultValue:.
+	
+	defaultValue := pragma arguments at: 3.
+	
+	
+	self assert: prop defaultValue equals: defaultValue.
+	self assert: prop defaultValue equals: aValue.
+	self assert: defaultValue equals: aValue.
+]
+
 { #category : #running }
 FMMetaMetaModelTest >> setUp [
 	super setUp.
@@ -25,6 +48,13 @@ FMMetaMetaModelTest >> testFM3Classes [
 	self assert: (metaMetaModel descriptionOf: FM3Package ifAbsent: [ nil ]) isNotNil.
 	self assert: (metaMetaModel descriptionOf: FM3Class ifAbsent: [ nil ]) isNotNil.
 	self assert: (metaMetaModel descriptionOf: FMMetaModelTest ifAbsent: [ nil ]) isNil
+]
+
+{ #category : #tests }
+FMMetaMetaModelTest >> testFM3DefaultValue [
+	self assertDefaultValueFor: 'FM3.Property.container' is: false.
+
+	
 ]
 
 { #category : #tests }

--- a/src/Fame-Tests/FMMetaMetaModelTest.class.st
+++ b/src/Fame-Tests/FMMetaMetaModelTest.class.st
@@ -69,8 +69,9 @@ FMMetaMetaModelTest >> testFM3IsComplete [
 	self assert: (names includes: 'FM3.Trait').
 	self assert: (names includes: 'FM3.Trait.primitive').
 	self assert: (names includes: 'FM3.Trait.root').
-	self assert: names size equals: 31.
-	self assert: (names select: [ :n | n beginsWith: 'FM3.' ]) size equals: 30
+	self assert: (names includes: 'FM3.Property.defaultValue').
+	self assert: names size equals: 32.
+	self assert: (names select: [ :n | n beginsWith: 'FM3.' ]) size equals: 31
 ]
 
 { #category : #tests }


### PR DESCRIPTION
This PR provides a first support for default values in Fame.

The mecanism put here could be refined and improved to deal with complex "data type" serialization and simplify current serialization/deserialization process, unifying the way data are read/written.