### PR TITLE
Fix multi value parsing and add tests

### DIFF
--- a/src/Fame-ImportExport/FMJSONParser.class.st
+++ b/src/Fame-ImportExport/FMJSONParser.class.st
@@ -73,13 +73,13 @@ FMJSONParser >> Entity [
 
 { #category : #tokens }
 FMJSONParser >> MultiEntity [
-	self tMultiOPEN
-		ifFalse: [ ^ self backtrack: self position ].
-	[ self Entity or: [ self Reference or: [ self Reference2 ] ].
+
+	self tMultiOPEN ifFalse: [ ^ self backtrack: self position ].
+	[ 
+	self Primitive or: [ self Reference or: [ self Reference2 or: [ self Entity ] ] ].
 	self incrementProgressBar.
 	self tPropertySeparator ] whileTrue.
-	self tMultiCLOSE
-		ifFalse: [ ^ self syntaxError ].
+	self tMultiCLOSE ifFalse: [ ^ self syntaxError ].
 	^ true
 ]
 

--- a/src/Fame-Tests/FMJSONParserTest.class.st
+++ b/src/Fame-Tests/FMJSONParserTest.class.st
@@ -888,6 +888,20 @@ FMJSONParserTest >> testMatchString [
 ]
 
 { #category : #tests }
+FMJSONParserTest >> testMultiValueString [
+	p fromString: '["public"]'.
+	p MultiEntity.
+	self assert: r exportJsonString equals: '"public"'
+]
+
+{ #category : #tests }
+FMJSONParserTest >> testMultiValueWithMultiString [
+	p fromString: '["public", "hello"]'.
+	p MultiEntity.
+	self assert: r exportJsonString equals: '"public""hello"'
+]
+
+{ #category : #tests }
 FMJSONParserTest >> testNumber [
 	p fromString: '14'.
 	r := p Number.


### PR DESCRIPTION
Enable importing of MultiValue

Example:

```st
(FamixJavaModel new importFromJSONStream: '[{
        "FM3":"Famix-Java-Entities.Class",
        "id":5,
        "modifiers":["public"],
        "name":"AutoCloseable",
        "isInterface":"true",
        "isStub":"true",
        "typeContainer": {"ref": 118}
        }]' readStream ) entities
```

I add two tests for this feature: `testMultiValueString` and `testMultiValueWithMultiString`
