### PR TITLE
Add a method to know if a property is a relation

### DIFF
--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -57,21 +57,6 @@ FM3Class >> accept: aVisitor [
 	^ aVisitor visitClass: self
 ]
 
-{ #category : #'accessing-query' }
-FM3Class >> allComplexProperties [
-	^ self allProperties reject: [ :attr | attr type isNotNil and: [ attr type isPrimitive ] ]
-]
-
-{ #category : #'accessing-query' }
-FM3Class >> allContainerProperties [
-	^ self allProperties select: #isContainer
-]
-
-{ #category : #'accessing-query' }
-FM3Class >> allPrimitiveProperties [
-	^ self allProperties select: [ :attr | attr type isNotNil and: [ attr type isPrimitive ] ]
-]
-
 { #category : #enumerating }
 FM3Class >> allPropertiesDo: block [
 	properties do: block.

--- a/src/Fame-Core/FM3Property.class.st
+++ b/src/Fame-Core/FM3Property.class.st
@@ -221,6 +221,17 @@ FM3Property >> isMultivalued: anObject [
 ]
 
 { #category : #accessing }
+FM3Property >> isRelation [
+
+	^ self hasOpposite and: [ 
+		  isContainer not and: [ 
+			  opposite isContainer not and: [ 
+				  isSource not and: [ 
+					  isTarget not and: [ 
+						  opposite isSource not and: [ opposite isTarget not ] ] ] ] ] ]
+]
+
+{ #category : #accessing }
 FM3Property >> isSource [
 	^ isSource
 ]

--- a/src/Fame-Core/FM3Trait.class.st
+++ b/src/Fame-Core/FM3Trait.class.st
@@ -19,21 +19,6 @@ FM3Trait >> accept: aVisitor [
 	^ aVisitor visitTrait: self
 ]
 
-{ #category : #'accessing-query' }
-FM3Trait >> allComplexProperties [
-	^ self allProperties reject: [ :attr | attr type isNotNil and: [ attr type isPrimitive ] ]
-]
-
-{ #category : #'accessing-query' }
-FM3Trait >> allContainerProperties [
-	^ self allProperties select: #isContainer
-]
-
-{ #category : #'accessing-query' }
-FM3Trait >> allPrimitiveProperties [
-	^ self allProperties select: [ :attr | attr type isNotNil and: [ attr type isPrimitive ] ]
-]
-
 { #category : #accessing }
 FM3Trait >> allSuperclasses [
 	| mmclass superclasses |

--- a/src/Fame-Core/FM3Type.class.st
+++ b/src/Fame-Core/FM3Type.class.st
@@ -27,6 +27,22 @@ FM3Type >> addTraits: aCollection [
 ]
 
 { #category : #'accessing-query' }
+FM3Type >> allComplexProperties [
+	^ self allProperties reject: [ :attr | attr type isNotNil and: [ attr type isPrimitive ] ]
+]
+
+{ #category : #'accessing-query' }
+FM3Type >> allContainerProperties [
+
+	^ self allProperties select: [ :property | property isContainer ]
+]
+
+{ #category : #'accessing-query' }
+FM3Type >> allPrimitiveProperties [
+	^ self allProperties select: [ :attr | attr type isNotNil and: [ attr type isPrimitive ] ]
+]
+
+{ #category : #'accessing-query' }
 FM3Type >> allProperties [
 	<FMProperty: #allProperties type: 'FM3.Property'>
 	<multivalued>
@@ -41,6 +57,12 @@ FM3Type >> allProperties [
 FM3Type >> allPropertiesDo: block [
 	self properties do: block.
 	self traits do: [ :trait | trait allPropertiesDo: block ]
+]
+
+{ #category : #'accessing-query' }
+FM3Type >> allRelationProperties [
+
+	^ self allProperties select: [ :property | property isRelation ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
i.e. has opposite, is not a scoping nor a navigation property.
+ refactorin of #allXYZProperties methods