### PR TITLE
Fix #56: Entities in a many-to-many relation can only be in the same relation once

### DIFF
--- a/src/Fame-Core/FMRelationSlot.class.st
+++ b/src/Fame-Core/FMRelationSlot.class.st
@@ -55,7 +55,7 @@ FMRelationSlot >> addAssociationFrom: ownerObject to: otherObject [
 	realInverseSlot isToOne
 		ifTrue: [ (realInverseSlot read: otherObject) ifNotNil: [ :oldObject | realInverseSlot removeAssociationFrom: otherObject to: oldObject ].
 			realInverseSlot writeInverse: ownerObject to: otherObject ]
-		ifFalse: [ (realInverseSlot read: otherObject) inverseAdd: ownerObject ]
+		ifFalse: [ (realInverseSlot read: otherObject) unsafeAdd: ownerObject ]
 ]
 
 { #category : #'code generation' }

--- a/src/Fame-Core/FMSlotMultivalueLink.class.st
+++ b/src/Fame-Core/FMSlotMultivalueLink.class.st
@@ -101,12 +101,6 @@ FMSlotMultivalueLink >> hash [
 ]
 
 { #category : #private }
-FMSlotMultivalueLink >> inverseAdd: anObject [
-
-	^values add: anObject
-]
-
-{ #category : #private }
 FMSlotMultivalueLink >> inverseRemove: anObject [
 
 	^values remove: anObject


### PR DESCRIPTION
Remove `FMSlotMultivalueLink>>inverseAdd:` and use `unsafeAdd:` instead.