### PR TITLE
Use 'unavailable' instead of the MooseUnavailableMetric class

### DIFF
--- a/src/Fame-ImportExport/FMModelExporter.class.st
+++ b/src/Fame-ImportExport/FMModelExporter.class.st
@@ -83,16 +83,16 @@ FMModelExporter >> exportProperty: property for: each [
 { #category : #exporting }
 FMModelExporter >> exportProperty: property withAll: values [
 
-	printer inProperty: property name do: [ 
+	printer inProperty: property name do: [
 		property isMultivalued ifTrue: [ printer beginMultivalue: property ].
-		(values reject: [ :value | value = MooseUnavailableMetric ])
-			do: [ :each | 
+		(values reject: [ :value | value asString = 'unavailable' "value = MooseUnavailableMetric" ])
+			do: [ :each |
 				property type isPrimitive
 					ifTrue: [ printer primitive: each ]
-					ifFalse: [ 
+					ifFalse: [
 						property isChildrenProperty
 							ifTrue: [ self exportEntity: each ]
-							ifFalse: [ 
+							ifFalse: [
 								(FM3Constant constants includes: each)
 									ifTrue: [ printer referenceName: each name ]
 									ifFalse: [ printer referenceNumber: (self indexOf: each) ] ] ] ]


### PR DESCRIPTION
to break circular dependency.

Not a perfect solution.