### PR TITLE
FMMultivalueLink inherits from SequenceableCollection

### DIFF
--- a/src/Fame-Core/FMMultivalueLink.class.st
+++ b/src/Fame-Core/FMMultivalueLink.class.st
@@ -32,7 +32,7 @@ that refers to it are updated accordingly.
 "
 Class {
 	#name : #FMMultivalueLink,
-	#superclass : #Collection,
+	#superclass : #SequenceableCollection,
 	#instVars : [
 		'values',
 		'owner',
@@ -40,6 +40,12 @@ Class {
 	],
 	#category : #'Fame-Core-Utilities'
 }
+
+{ #category : #'instance creation' }
+FMMultivalueLink class >> new: size [
+
+	^ self new setCollection: (OrderedCollection new: size)
+]
 
 { #category : #'instance creation' }
 FMMultivalueLink class >> on: element opposite: oppositeSelector [
@@ -119,48 +125,14 @@ FMMultivalueLink >> do: aBlock [
 	values do: aBlock
 ]
 
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> eighth [
-	^ self at: 8
-]
-
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> fifth [
-	^ self at: 5
-]
-
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> first [
-	^ self at: 1
-]
-
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> fourth [
-	^ self at: 4
-]
-
-{ #category : #comparing }
-FMMultivalueLink >> hash [
-	"From sequenceable collection"
-	| hash |
-	hash := self species hash.
-	1 to: self size do: [ :i | hash := (hash + (self at: i) hash) hashMultiply ].
-	^ hash
-]
-
 { #category : #iterators }
 FMMultivalueLink >> iterator [
 	^ values iterator
 ]
 
-{ #category : #'accessing-computed' }
+{ #category : #accessing }
 FMMultivalueLink >> last [
 	^ values last
-]
-
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> ninth [
-	^ self at: 9
 ]
 
 { #category : #copying }
@@ -190,19 +162,10 @@ FMMultivalueLink >> removeAll [
 		do: [ :anElement | anElement perform: opposite with: nil ]
 ]
 
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> second [
-	^ self at: 2
-]
+{ #category : #initialization }
+FMMultivalueLink >> setCollection: aCollection [
 
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> seventh [
-	^ self at: 7
-]
-
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> sixth [
-	^ self at: 6
+	values := aCollection
 ]
 
 { #category : #accessing }
@@ -215,11 +178,6 @@ FMMultivalueLink >> size [
 FMMultivalueLink >> species [
 
 	^OrderedCollection
-]
-
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> third [
-	^ self at: 3
 ]
 
 { #category : #private }


### PR DESCRIPTION
Instead of Collection.

Add `new:` to be compatible with the SequenceableCollection API.
Add `setCollection:` to make `new:` work with the intended pre-sizing mechanism.
Remove `hash` and `first` to `ninth` because they are defined in SequenceableCollection.

This might make FMMultivalueLink faster because of the optimized versions of `select:thenCollect:`&co, although I haven't tried it.

I'm also considering about removing the `=` method, which only differs from SequenceableCollection's by calling `asOrderedCollection` on the other collection, but that may be unnecessary (and thus slower for no reason).
```st
	self == otherCollection ifTrue: [^ true].
	self species == otherCollection species ifFalse: [^ false].
	^ values hasEqualElements: otherCollection "=>" asOrderedCollection "<= unnecessary?"
```