### PR TITLE
Close #69: FMMultivalueLink inherits from OrderedCollection

### DIFF
--- a/src/Fame-Core/FMMultiMultivalueLink.class.st
+++ b/src/Fame-Core/FMMultiMultivalueLink.class.st
@@ -25,58 +25,50 @@ Class {
 }
 
 { #category : #adding }
-FMMultiMultivalueLink >> add: anElement [
-	(anElement perform: opposite) unsafeAdd: owner.
-	(values includes: anElement) ifFalse: [ values add: anElement ].
-	^ anElement
+FMMultiMultivalueLink >> addOpposite: anElement [
+
+	(anElement perform: opposite) unsafeAdd: owner
 ]
 
 { #category : #removing }
-FMMultiMultivalueLink >> remove: anElement ifAbsent: exceptionBlock [ 
-	
-	values remove: anElement ifAbsent: [ ^exceptionBlock value ].
-	(anElement perform: opposite) unsafeRemove: owner.
-	^anElement
-]
+FMMultiMultivalueLink >> removeOpposite: anElement [
 
-{ #category : #removing }
-FMMultiMultivalueLink >> removeAll [
-	values reversed
-		do: [ :anElement | (anElement perform: opposite) remove: owner ]
+	(anElement perform: opposite) unsafeRemove: owner
 ]
 
 { #category : #'private - adding' }
-FMMultiMultivalueLink >> uncheckAdd: anElement [ 
+FMMultiMultivalueLink >> uncheckAdd: anElement [
+
 	(anElement perform: opposite) uncheckUnsafeAdd: owner.
-	values add: anElement.
+	self uncheckUnsafeAdd: anElement.
 	^ anElement
 ]
 
 { #category : #'private - adding' }
-FMMultiMultivalueLink >> uncheckAddAll: aCollection [ 
+FMMultiMultivalueLink >> uncheckAddAll: aCollection [
 	"Include all the elements of aCollection as the receiver's elements. Answer 
 	aCollection. Actually, any object responding to #do: can be used as argument."
+
 	aCollection do: [ :each | self uncheckAdd: each ].
 	^ aCollection
-]
-
-{ #category : #'private - adding' }
-FMMultiMultivalueLink >> uncheckUnsafeAdd: element [ 
-	values add: element
 ]
 
 { #category : #adding }
 FMMultiMultivalueLink >> value: aCollection [
 
 	^ self
-		  removeAll: values copy;
-		  uncheckAddAll: aCollection asOrderedCollection removeDuplicates
+		  removeAll;
+		  "We want unique elements and to keep the order, but `removeDuplicates` is really slow."
+		  uncheckAddAll: (aCollection
+				   collect: [ :element | element -> nil ]
+				   as: OrderedDictionary) keys
 ]
 
 { #category : #private }
 FMMultiMultivalueLink >> with: element opposite: oppositeSelector [
+
 	self assert: oppositeSelector numArgs = 0.
-	values := OrderedCollection new.
+	self setContents: #(  ).
 	owner := element.
 	opposite := oppositeSelector
 ]

--- a/src/Fame-Core/FMMultivalueLink.class.st
+++ b/src/Fame-Core/FMMultivalueLink.class.st
@@ -32,9 +32,8 @@ that refers to it are updated accordingly.
 "
 Class {
 	#name : #FMMultivalueLink,
-	#superclass : #Collection,
+	#superclass : #OrderedCollection,
 	#instVars : [
-		'values',
 		'owner',
 		'opposite'
 	],
@@ -58,116 +57,47 @@ FMMultivalueLink class >> on: element update: selector from: old to: new [
 	^ new
 ]
 
-{ #category : #copying }
-FMMultivalueLink >> , aCollection [
-	^ self asOrderedCollection , aCollection
-]
-
-{ #category : #comparing }
-FMMultivalueLink >> = otherCollection [ 
-	"Answer true if the receiver is equivalent to the otherCollection.
-	First test for identity, then rule out different species and sizes of
-	collections. As a last resort, examine each element of the receiver
-	and the otherCollection."
-
-	self == otherCollection ifTrue: [^ true].
-	self species == otherCollection species ifFalse: [^ false].
-	^ values hasEqualElements: otherCollection asOrderedCollection
-]
-
 { #category : #adding }
-FMMultivalueLink >> add: anElement [
-	anElement perform: opposite with: owner.
+FMMultivalueLink >> addLast: anElement [
+
+	self addOpposite: anElement.
 	self unsafeAdd: anElement.
 	^ anElement
 ]
 
-{ #category : #accessing }
-FMMultivalueLink >> at: index [
+{ #category : #adding }
+FMMultivalueLink >> addOpposite: anElement [
 
-	^values at: index
+	anElement perform: opposite with: owner
 ]
 
-{ #category : #iterators }
-FMMultivalueLink >> basicIterator [
-	^ values basicIterator
+{ #category : #converting }
+FMMultivalueLink >> asOrderedCollection [
+
+	^ OrderedCollection newFrom: self
 ]
 
 { #category : #accessing }
 FMMultivalueLink >> byName: name [
+
 	^ self byName: name ifAbsent: [ self errorNotFound: name ]
 ]
 
 { #category : #accessing }
 FMMultivalueLink >> byName: name ifAbsent: exceptionBlock [
-	^ values
-		detect: [ :each | each name asString = name asString ]
-		ifNone: exceptionBlock
+
+	^ self
+		  detect: [ :each | each name asString = name asString ]
+		  ifNone: exceptionBlock
 ]
 
 { #category : #accessing }
 FMMultivalueLink >> byName: name ifPresent: aBlock ifAbsent: exceptionBlock [
-	^ values
-		detect: [ :each | each name asString = name asString ]
-		ifFound: aBlock
-		ifNone: exceptionBlock
-]
 
-{ #category : #enumerating }
-FMMultivalueLink >> do: aBlock [ 
-	
-	values do: aBlock
-]
-
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> eighth [
-	^ self at: 8
-]
-
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> fifth [
-	^ self at: 5
-]
-
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> first [
-	^ self at: 1
-]
-
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> fourth [
-	^ self at: 4
-]
-
-{ #category : #comparing }
-FMMultivalueLink >> hash [
-	"From sequenceable collection"
-	| hash |
-	hash := self species hash.
-	1 to: self size do: [ :i | hash := (hash + (self at: i) hash) hashMultiply ].
-	^ hash
-]
-
-{ #category : #iterators }
-FMMultivalueLink >> iterator [
-	^ values iterator
-]
-
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> last [
-	^ values last
-]
-
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> ninth [
-	^ self at: 9
-]
-
-{ #category : #copying }
-FMMultivalueLink >> postCopy [
-
-	super postCopy.
-	values := values copy.
+	^ self
+		  detect: [ :each | each name asString = name asString ]
+		  ifFound: aBlock
+		  ifNone: exceptionBlock
 ]
 
 { #category : #printing }
@@ -177,79 +107,65 @@ FMMultivalueLink >> printOn: aStream [
 ]
 
 { #category : #removing }
-FMMultivalueLink >> remove: anElement ifAbsent: exceptionBlock [ 
-	
-	values remove: anElement ifAbsent: [ ^exceptionBlock value ].
-	anElement perform: opposite with: nil.
-	^anElement
+FMMultivalueLink >> remove: anElement ifAbsent: exceptionBlock [
+
+	super remove: anElement ifAbsent: [ ^ exceptionBlock value ].
+	self removeOpposite: anElement.
+	^ anElement
 ]
 
 { #category : #removing }
 FMMultivalueLink >> removeAll [
-	values reversed
-		do: [ :anElement | anElement perform: opposite with: nil ]
+	"The collection is reversed to make a copy, to avoid trying to remove while iterating,
+	and to remove items from last to first, which is faster."
+
+	self reversed do: [ :anElement | self remove: anElement ]
 ]
 
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> second [
-	^ self at: 2
-]
+{ #category : #removing }
+FMMultivalueLink >> removeOpposite: anElement [
 
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> seventh [
-	^ self at: 7
-]
-
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> sixth [
-	^ self at: 6
-]
-
-{ #category : #accessing }
-FMMultivalueLink >> size [
-
-	^values size
+	anElement perform: opposite with: nil
 ]
 
 { #category : #private }
 FMMultivalueLink >> species [
 
-	^OrderedCollection
+	^ OrderedCollection
 ]
 
-{ #category : #'accessing-computed' }
-FMMultivalueLink >> third [
-	^ self at: 3
+{ #category : #private }
+FMMultivalueLink >> uncheckUnsafeAdd: element [
+	"Calls the implementation in OrderedCollection."
+
+	super addLast: element
 ]
 
 { #category : #private }
 FMMultivalueLink >> unsafeAdd: element [
-	(values includes: element)
-		ifFalse: [ values add: element ]
+
+	(self includes: element) ifFalse: [ super addLast: element ]
 ]
 
 { #category : #private }
 FMMultivalueLink >> unsafeRemove: element [
 
-	values remove: element ifAbsent: nil
+	super remove: element ifAbsent: nil
 ]
 
 { #category : #adding }
 FMMultivalueLink >> value: aCollection [
 
-	^self removeAll: values copy; addAll: aCollection
+	^ self
+		  removeAll;
+		  addAll: aCollection
 ]
 
 { #category : #private }
 FMMultivalueLink >> with: element opposite: oppositeSelector [
+
 	self assert: oppositeSelector numArgs = 1.
-	values := OrderedCollection new.
+	self setContents: #(  ).
 	owner := element.
 	opposite := oppositeSelector
-]
-
-{ #category : #enumerating }
-FMMultivalueLink >> withIndexDo: aBlock [ 
-	
-	values withIndexDo: aBlock
 ]

--- a/src/Fame-Tests/FMMultiMultivalueLinkTest.class.st
+++ b/src/Fame-Tests/FMMultiMultivalueLinkTest.class.st
@@ -8,6 +8,37 @@ Class {
 }
 
 { #category : #tests }
+FMMultiMultivalueLinkTest >> testCollect [
+
+	| dragon1 hero1 |
+	dragon1 := RPGDragon new.
+	hero1 := RPGHero new.
+	hero1 kills: { dragon1 }.
+	self
+		assert: (hero1 kills collect: [ :dragon | dragon ])
+		equals: { dragon1 } asOrderedCollection
+]
+
+{ #category : #tests }
+FMMultiMultivalueLinkTest >> testCollectThenSelect [
+
+	| dragon1 dragon2 hero1 treasure1 |
+	dragon1 := RPGDragon new.
+	dragon2 := RPGDragon new.
+	hero1 := RPGHero new.
+	treasure1 := RPGTreasure new.
+	dragon1 hoard: { treasure1 }.
+	hero1 kills: {
+			dragon1.
+			dragon2 }.
+	self
+		assertCollection: (hero1 kills
+				 collect: [ :dragon | dragon hoard asArray ]
+				 thenSelect: [ :hoard | hoard isNotEmpty ])
+		hasSameElements: { { treasure1 } }
+]
+
+{ #category : #tests }
 FMMultiMultivalueLinkTest >> testOneDragonIsKilledByOneHero [
 
 	| dragon1 hero1 |
@@ -123,6 +154,84 @@ FMMultiMultivalueLinkTest >> testOneHeroKilledLotOfDragon [
 	hero1 := RPGHero new.
 	hero1 kills: dragons.
 	self assert: hero1 kills size equals: 50000.
+]
+
+{ #category : #tests }
+FMMultiMultivalueLinkTest >> testReject [
+
+	| dragon1 dragon2 hero1 treasure1 |
+	dragon1 := RPGDragon new.
+	dragon2 := RPGDragon new.
+	hero1 := RPGHero new.
+	treasure1 := RPGTreasure new.
+	dragon1 hoard: { treasure1 }.
+	hero1 kills: {
+			dragon1.
+			dragon2 }.
+	self
+		assert: (hero1 kills reject: [ :dragon | dragon hoard isNotEmpty ])
+		equals: { dragon2 } asOrderedCollection.
+	self
+		assert: (hero1 kills reject: [ :dragon | dragon hoard isEmpty ])
+		equals: { dragon1 } asOrderedCollection
+]
+
+{ #category : #tests }
+FMMultiMultivalueLinkTest >> testRejectThenCollect [
+
+	| dragon1 dragon2 hero1 treasure1 |
+	dragon1 := RPGDragon new.
+	dragon2 := RPGDragon new.
+	hero1 := RPGHero new.
+	treasure1 := RPGTreasure new.
+	dragon1 hoard: { treasure1 }.
+	hero1 kills: {
+			dragon1.
+			dragon2 }.
+	self
+		assert: (hero1 kills
+				 reject: [ :dragon | dragon hoard isEmpty ]
+				 thenCollect: [ :dragon | dragon hoard anyOne ])
+		equals: { treasure1 } asOrderedCollection
+]
+
+{ #category : #tests }
+FMMultiMultivalueLinkTest >> testSelect [
+
+	| dragon1 dragon2 hero1 treasure1 |
+	dragon1 := RPGDragon new.
+	dragon2 := RPGDragon new.
+	hero1 := RPGHero new.
+	treasure1 := RPGTreasure new.
+	dragon1 hoard: { treasure1 }.
+	hero1 kills: {
+			dragon1.
+			dragon2 }.
+	self
+		assert: (hero1 kills select: [ :dragon | dragon hoard isNotEmpty ])
+		equals: { dragon1 } asOrderedCollection.
+	self
+		assert: (hero1 kills select: [ :dragon | dragon hoard isEmpty ])
+		equals: { dragon2 } asOrderedCollection
+]
+
+{ #category : #tests }
+FMMultiMultivalueLinkTest >> testSelectThenCollect [
+
+	| dragon1 dragon2 hero1 treasure1 |
+	dragon1 := RPGDragon new.
+	dragon2 := RPGDragon new.
+	hero1 := RPGHero new.
+	treasure1 := RPGTreasure new.
+	dragon1 hoard: { treasure1 }.
+	hero1 kills: {
+			dragon1.
+			dragon2 }.
+	self
+		assert: (hero1 kills
+				 select: [ :dragon | dragon hoard isNotEmpty ]
+				 thenCollect: [ :dragon | dragon hoard anyOne ])
+		equals: { treasure1 } asOrderedCollection
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Closes #66: Add more tests for the collection API on links.

This has been tested on Fame, Famix, Moose, [Casino](https://github.com/badetitou/Casino) and [Modest](https://github.com/Evref-BL/Modest).
Everything seems to work fine with the way the API has been used so far.
Note, however, that extending OrderedCollection adds a lot of API to FMMultivalueLink, and not all of it has been tested.
For example, `addFirst:` does not *yet* implement a hook to set the opposite and check for unicity.