### PR TITLE
Cache number parser to not create too many instances

### DIFF
--- a/src/Fame-ImportExport/FMMSEParser.class.st
+++ b/src/Fame-ImportExport/FMMSEParser.class.st
@@ -90,7 +90,7 @@ FMMSEParser >> Identifier [
 	buffer nextPut: chararacter.
 	[ self characterSet isDigit: self next ] whileTrue: [ buffer nextPut: chararacter ].
 	self tWHITESPACE.
-	^ Integer readFrom: buffer contents readStream
+	^ (numberParser on: buffer contents readStream) nextInteger
 ]
 
 { #category : #expressions }

--- a/src/Fame-ImportExport/FMMSEParser.class.st
+++ b/src/Fame-ImportExport/FMMSEParser.class.st
@@ -27,7 +27,8 @@ Class {
 		'characterSet',
 		'chararacter',
 		'buffer',
-		'importer'
+		'importer',
+		'numberParser'
 	],
 	#category : #'Fame-ImportExport-Importers'
 }
@@ -137,7 +138,7 @@ FMMSEParser >> Number [
 					self characterSet isDigit: self next ] whileTrue
 					")?)?" ] ].
 	self tWHITESPACE.
-	^ Number readFrom: buffer contents readStream
+	^ (numberParser on: buffer contents readStream) nextNumber
 ]
 
 { #category : #expressions }
@@ -290,6 +291,13 @@ FMMSEParser >> incrementProgressBar [
 	(progBar isNotNil and: [ (Time millisecondsSince: lastUpdate) >= 500 ]) ifFalse: [ ^ self ].
 	progBar value: self position.
 	lastUpdate := Time millisecondClockValue
+]
+
+{ #category : #initialization }
+FMMSEParser >> initialize [
+
+	super initialize.
+	numberParser := NumberParser new
 ]
 
 { #category : #tokens }


### PR DESCRIPTION
This change caches the number parser. During the import of a model the number parser represented 5% en the objects created. With this change we only create 1. 