### PR TITLE
Fix JSON Syntax error when exporting an entity with no properties.

### DIFF
--- a/src/Fame-ImportExport/FMJSONPrinter.class.st
+++ b/src/Fame-ImportExport/FMJSONPrinter.class.st
@@ -115,9 +115,8 @@ FMJSONPrinter >> referenceNumber: index [
 
 { #category : #parsing }
 FMJSONPrinter >> serial: index [
-	
-	stream 
+
+	stream
 		nextPutAll: '"id":';
-		print: index;
-		nextPut: $,
+		print: index
 ]

--- a/src/Fame-ImportExport/FMModelExporter.class.st
+++ b/src/Fame-ImportExport/FMModelExporter.class.st
@@ -61,15 +61,19 @@ FMModelExporter >> export: aCollectionOfElements [
 
 { #category : #exporting }
 FMModelExporter >> exportEntity: each [
+
 	| meta |
 	meta := model metaDescriptionOf: each.
-	printer
-		inEntity: meta fullName
-		do: [ printer serial: (self indexOf: each).
-			((self sortedPropertiesOf: meta)
-				select: [ :property | self shouldExportProperty: property for: each ])
-				do: [ :property | self exportProperty: property for: each ]
-				separatedBy: [ printer printPropertySeparator ] ].
+	printer inEntity: meta fullName do: [
+		| sortedProperties |
+		printer serial: (self indexOf: each).
+		sortedProperties := (self sortedPropertiesOf: meta) select: [
+			                    :property |
+			                    self shouldExportProperty: property for: each ].
+		sortedProperties ifNotEmpty: [ printer printPropertySeparator ].
+		sortedProperties
+			do: [ :property | self exportProperty: property for: each ]
+			separatedBy: [ printer printPropertySeparator ] ].
 	self incrementProgressBar
 ]
 


### PR DESCRIPTION
Co-authored-by: IkiAde <ikimathadeoye@gmail.com>