### PR TITLE
When generating metamodels, #traits should only be local traits.

### DIFF
--- a/src/Fame-Core/Behavior.extension.st
+++ b/src/Fame-Core/Behavior.extension.st
@@ -2,5 +2,12 @@ Extension { #name : #Behavior }
 
 { #category : #'*Fame-Core' }
 Behavior >> allGeneratedTraits [
-	^ self traitComposition allTraits select: #isMetamodelEntity
+
+	^ self allTraits select: #isMetamodelEntity
+]
+
+{ #category : #'*Fame-Core' }
+Behavior >> localGeneratedTraits [
+
+	^ self traits select: #isMetamodelEntity
 ]

--- a/src/Fame-Core/FMMetaModelBuilder.class.st
+++ b/src/Fame-Core/FMMetaModelBuilder.class.st
@@ -223,7 +223,7 @@ FMMetaModelBuilder >> processClass: aClass ifPragmaAbsent: anErrorBlock [
 					aClass localSlots
 						select: #isFMRelationSlot
 						thenDo: [ :each | self processSlot: each in: aClass ].
-					traitsDict at: fm3Class put: aClass allGeneratedTraits.
+					traitsDict at: fm3Class put: aClass localGeneratedTraits.
 					elements add: fm3Class ] ]
 ]
 
@@ -309,7 +309,7 @@ FMMetaModelBuilder >> processTrait: aTrait ifPragmaAbsent: anErrorBlock [
 					aTrait localSlots
 						select: #isFMRelationSlot
 						thenDo: [ :each | self processSlot: each in: aTrait ].
-					traitsDict at: fm3Trait put: aTrait allGeneratedTraits.
+					traitsDict at: fm3Trait put: aTrait localGeneratedTraits.
 					elements add: fm3Trait ]
 ]
 


### PR DESCRIPTION
It will still be possible to access all traits transitively using #allGeneratedTraits.