### PR TITLE
`FMSlotMultivalueLink >> #asOrderedCollection` now returns an OrderedCollection

### DIFF
--- a/src/Fame-Core/FMSlotMultivalueLink.class.st
+++ b/src/Fame-Core/FMSlotMultivalueLink.class.st
@@ -31,6 +31,12 @@ FMSlotMultivalueLink >> addLast: anElement [
 	^ anElement
 ]
 
+{ #category : #converting }
+FMSlotMultivalueLink >> asOrderedCollection [
+
+	^ OrderedCollection newFrom: self
+]
+
 { #category : #accessing }
 FMSlotMultivalueLink >> byName: name [
 


### PR DESCRIPTION
Fixes moosetechnology/Famix#874.