### PR TITLE
Make Links be initialized with an empty array

### DIFF
--- a/src/Fame-Core/FMMultiMultivalueLink.class.st
+++ b/src/Fame-Core/FMMultiMultivalueLink.class.st
@@ -68,7 +68,6 @@ FMMultiMultivalueLink >> value: aCollection [
 FMMultiMultivalueLink >> with: element opposite: oppositeSelector [
 
 	self assert: oppositeSelector numArgs = 0.
-	self setContents: #(  ).
 	owner := element.
 	opposite := oppositeSelector
 ]

--- a/src/Fame-Core/FMMultivalueLink.class.st
+++ b/src/Fame-Core/FMMultivalueLink.class.st
@@ -43,7 +43,7 @@ Class {
 { #category : #'instance creation' }
 FMMultivalueLink class >> new [
 
-	^ self new: 0
+	^ self new: 4
 ]
 
 { #category : #'instance creation' }

--- a/src/Fame-Core/FMMultivalueLink.class.st
+++ b/src/Fame-Core/FMMultivalueLink.class.st
@@ -41,6 +41,12 @@ Class {
 }
 
 { #category : #'instance creation' }
+FMMultivalueLink class >> new [
+
+	^ self new: 0
+]
+
+{ #category : #'instance creation' }
 FMMultivalueLink class >> on: element opposite: oppositeSelector [
 	^ self new
 		with: element opposite: oppositeSelector;
@@ -51,9 +57,9 @@ FMMultivalueLink class >> on: element opposite: oppositeSelector [
 FMMultivalueLink class >> on: element update: selector from: old to: new [
 	"refresh the other side of the relations to reflect change in value"
 
-	old ~= new
-		ifTrue: [ old ifNotNil: [ (old perform: selector) unsafeRemove: element ].
-			new ifNotNil: [ (new perform: selector) unsafeAdd: element ] ].
+	old ~= new ifTrue: [
+		old ifNotNil: [ (old perform: selector) unsafeRemove: element ].
+		new ifNotNil: [ (new perform: selector) unsafeAdd: element ] ].
 	^ new
 ]
 
@@ -165,7 +171,6 @@ FMMultivalueLink >> value: aCollection [
 FMMultivalueLink >> with: element opposite: oppositeSelector [
 
 	self assert: oppositeSelector numArgs = 1.
-	self setContents: #(  ).
 	owner := element.
 	opposite := oppositeSelector
 ]

--- a/src/Fame-Core/FMSlotMultivalueLink.class.st
+++ b/src/Fame-Core/FMSlotMultivalueLink.class.st
@@ -19,7 +19,7 @@ Class {
 { #category : #'instance creation' }
 FMSlotMultivalueLink class >> new [
 
-	^ self new: 0
+	^ self new: 4
 ]
 
 { #category : #'instance creation' }

--- a/src/Fame-Core/FMSlotMultivalueLink.class.st
+++ b/src/Fame-Core/FMSlotMultivalueLink.class.st
@@ -17,6 +17,12 @@ Class {
 }
 
 { #category : #'instance creation' }
+FMSlotMultivalueLink class >> new [
+
+	^ self new: 0
+]
+
+{ #category : #'instance creation' }
 FMSlotMultivalueLink class >> on: anObject slot: aFMRelationSlot [
 
 	^ self new owner: anObject slot: aFMRelationSlot


### PR DESCRIPTION
Since Links inherit from OrderedCollection, they inherit the initialization logic that makes them start with an array of 10 elements, which is very bad for memory usage when so many instantiated Links are just empty!
Starting with 10 elements in the inner collection is an optimization for OrderedCollection, because more elements can be added before needing to grow the array, and the array would also grow faster if it starts bigger (it doubles in size).
Because links are not meant to have elements added to them except when creating a model, this might hurt performance a bit during the creation, but I think this is an acceptable tradeoff for the amount of unused memory we are currently wasting.

Another solution would be to ask the Links to `compact` after a model has been created to remove unused memory, which in the worst case can be up to half of a Link's array. This can be complementary to the change in this PR.