### PR TITLE
Use setter if a property is not found on import

### DIFF
--- a/src/Fame-ImportExport/Object.extension.st
+++ b/src/Fame-ImportExport/Object.extension.st
@@ -2,10 +2,24 @@ Extension { #name : #Object }
 
 { #category : #'*Fame-ImportExport' }
 Object >> handleFameProperty: aSymbol value: anObject [
-	"override me if you want your object to deal with undefined properties loaded from MSE"
+	"Override me if you want your object to deal with undefined properties loaded from a JSON.
+	
+	By default I'm logging the error and checking if we have a setter not metadescribed with the name of the property to execute. I return true if this is the case."
 
-	self traceCr:
-		'Unknown property ''' , aSymbol , ''' in ' , self class asString
+	| setter |
+	setter := aSymbol asSymbol asMutator.
+	self traceCr: 'Unknown property ''' , aSymbol , ''' in ' , self class asString.
+
+	^ (self respondsTo: setter)
+		  ifTrue: [
+				  | value |
+				  value := (anObject isCollection and: [ anObject size = 1 ])
+					           ifTrue: [ anObject anyOne ]
+					           ifFalse: [ anObject ].
+				  self traceCr: 'Setter of the same name than the property detected. Falling back to this method.'.
+				  self perform: setter with: value.
+				  true ]
+		  ifFalse: [ false ]
 ]
 
 { #category : #'*Fame-ImportExport' }


### PR DESCRIPTION
In the case a property is not found during an import, check if we have a corresponding setter to use