### PR TITLE
Speed up the import of JSON/MSE files

### DIFF
--- a/src/Fame-Core/FMMultivalueLink.class.st
+++ b/src/Fame-Core/FMMultivalueLink.class.st
@@ -151,8 +151,11 @@ FMMultivalueLink >> uncheckUnsafeAdd: element [
 
 { #category : 'private' }
 FMMultivalueLink >> unsafeAdd: element [
+	"The cost of this #includes can be pretty high so there is a way to disable it when we know there will be no duplicates. Check the class comment of the dynamic variable."
 
-	(self includes: element) ifFalse: [ super addLast: element ]
+	FMShouldCheckForDuplicatedEntitiesInMultivalueLinks value
+		ifTrue: [ (self includes: element) ifFalse: [ self uncheckUnsafeAdd: element ] ]
+		ifFalse: [ self uncheckUnsafeAdd: element ]
 ]
 
 { #category : 'private' }

--- a/src/Fame-Core/FMShouldCheckForDuplicatedEntitiesInMultivalueLinks.class.st
+++ b/src/Fame-Core/FMShouldCheckForDuplicatedEntitiesInMultivalueLinks.class.st
@@ -1,0 +1,30 @@
+"
+## Description
+
+I am a dynamic variable used by implementations of multivalue links to know if we should check for duplicated entities in multivalue links.
+
+For example, when importing a json, we are sure we will never add two times the same entity to a multivalue link. 
+
+I exist for performance reason because the cost of checking for duplicated entities is high. 
+
+By default I will enable the check.
+
+## Usage
+
+```smalltalk
+FMShouldCheckForDuplicatedEntitiesInMultivalueLinks value: false during: [ self importModel ]
+```
+"
+Class {
+	#name : 'FMShouldCheckForDuplicatedEntitiesInMultivalueLinks',
+	#superclass : 'DynamicVariable',
+	#category : 'Fame-Core-Utilities',
+	#package : 'Fame-Core',
+	#tag : 'Utilities'
+}
+
+{ #category : 'accessing' }
+FMShouldCheckForDuplicatedEntitiesInMultivalueLinks >> default [
+
+	^ true
+]

--- a/src/Fame-Core/FMSlotMultivalueLink.class.st
+++ b/src/Fame-Core/FMSlotMultivalueLink.class.st
@@ -106,8 +106,11 @@ FMSlotMultivalueLink >> uncheckUnsafeAdd: element [
 
 { #category : 'private' }
 FMSlotMultivalueLink >> unsafeAdd: element [
+	"The cost of this #includes can be pretty high so there is a way to disable it when we know there will be no duplicates. Check the class comment of the dynamic variable."
 
-	(self includes: element) ifFalse: [ super addLast: element ]
+	FMShouldCheckForDuplicatedEntitiesInMultivalueLinks value
+		ifTrue: [ (self includes: element) ifFalse: [ self uncheckUnsafeAdd: element ] ]
+		ifFalse: [ self uncheckUnsafeAdd: element ]
 ]
 
 { #category : 'private' }

--- a/src/Fame-ImportExport/FMMSEParser.class.st
+++ b/src/Fame-ImportExport/FMMSEParser.class.st
@@ -264,8 +264,11 @@ FMMSEParser >> backtrack: integer [
 
 { #category : 'running' }
 FMMSEParser >> basicRun [
-	self Document.
-	self atEnd ifFalse: [ ^ self syntaxError ]
+	"During the parsing of MSE files we know there will be no duplicates in collections so we can disable the check."
+
+	FMShouldCheckForDuplicatedEntitiesInMultivalueLinks value: false during: [
+			self Document.
+			self atEnd ifFalse: [ ^ self syntaxError ] ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This change is disabling the check for duplicated elements in multivalued collections during the import of MSE/JSON files since there should be no duplicated elements. 

With this a model I had that was taking 351sec to load is now down to 113sec