### PR TITLE
Invalidate the slots caches when regenerating a MM

### DIFF
--- a/src/Fame-Core/FMMetaModelBuilder.class.st
+++ b/src/Fame-Core/FMMetaModelBuilder.class.st
@@ -291,6 +291,8 @@ FMMetaModelBuilder >> processSlot: aSlot in: aClass [
 	oppositeDict at: prop put: aSlot inverseName.
 
 	aClass compiledMethodAt: aSlot name asSymbol ifPresent: [ :aMethod | self processInfosFrom: aMethod for: prop ].
+	
+	aSlot resetInverseSlotsCache. "Regenerating the MM means we might change relations. So we invalidate the slot cache since the content will change. I am not sure this is the best place. Ideally we should have a mecanism in the class builder but it's not the case for now."
 
 	elements add: prop
 ]

--- a/src/Fame-Core/FMRelationSlot.class.st
+++ b/src/Fame-Core/FMRelationSlot.class.st
@@ -119,8 +119,9 @@ FMRelationSlot >> inClass: aTargetClassOrSymbol [
 
 { #category : 'initialization' }
 FMRelationSlot >> initialize [
+
 	super initialize.
-	inverseSlotDic := IdentityDictionary new
+	self resetInverseSlotsCache
 ]
 
 { #category : 'initialization' }
@@ -186,6 +187,8 @@ FMRelationSlot >> printOn: aStream [
 
 { #category : 'accessing' }
 FMRelationSlot >> realInverseSlotFor: anObject [
+	"The inverseSlotDic needs to be flushed if an opposite slot is changing. This is done by the metamodel builder. It invalidates the caches of all slots in the MM to build."
+
 	^ inverseSlotDic at: anObject class ifAbsentPut: [ anObject class slotNamed: self inverseName ]
 ]
 
@@ -201,6 +204,12 @@ FMRelationSlot >> removeAssociationFrom: ownerObject to: otherObject [
 	realInverseSlot isToOne
 		ifTrue: [ realInverseSlot writeInverse: nil to: otherObject ]
 		ifFalse: [ (realInverseSlot read: otherObject) unsafeRemove: ownerObject ]
+]
+
+{ #category : 'initialization' }
+FMRelationSlot >> resetInverseSlotsCache [
+
+	inverseSlotDic := IdentityDictionary new
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
The FMRelationSlot has a cache that needs to be invalidated if we change an opposite. 

It's hard to do it a the class recompilation level so I do it at the MM building level