### PR TITLE
Remove cache of #realInverseSlotFor:

### DIFF
--- a/src/Fame-Core/FMMetaModelBuilder.class.st
+++ b/src/Fame-Core/FMMetaModelBuilder.class.st
@@ -291,8 +291,6 @@ FMMetaModelBuilder >> processSlot: aSlot in: aClass [
 	oppositeDict at: prop put: aSlot inverseName.
 
 	aClass compiledMethodAt: aSlot name asSymbol ifPresent: [ :aMethod | self processInfosFrom: aMethod for: prop ].
-	
-	aSlot resetInverseSlotsCache. "Regenerating the MM means we might change relations. So we invalidate the slot cache since the content will change. I am not sure this is the best place. Ideally we should have a mecanism in the class builder but it's not the case for now."
 
 	elements add: prop
 ]

--- a/src/Fame-Core/FMRelationSlot.class.st
+++ b/src/Fame-Core/FMRelationSlot.class.st
@@ -26,8 +26,7 @@ Class {
 	#superclass : 'InstanceVariableSlot',
 	#instVars : [
 		'targetClass',
-		'inverseName',
-		'inverseSlotDic'
+		'inverseName'
 	],
 	#category : 'Fame-Core-Utilities',
 	#package : 'Fame-Core',
@@ -118,13 +117,6 @@ FMRelationSlot >> inClass: aTargetClassOrSymbol [
 ]
 
 { #category : 'initialization' }
-FMRelationSlot >> initialize [
-
-	super initialize.
-	self resetInverseSlotsCache
-]
-
-{ #category : 'initialization' }
 FMRelationSlot >> inverse: anInverseSymbol inClass: aTargetClassOrSymbol [
 	self inClass: aTargetClassOrSymbol.
 	inverseName := anInverseSymbol
@@ -187,9 +179,8 @@ FMRelationSlot >> printOn: aStream [
 
 { #category : 'accessing' }
 FMRelationSlot >> realInverseSlotFor: anObject [
-	"The inverseSlotDic needs to be flushed if an opposite slot is changing. This is done by the metamodel builder. It invalidates the caches of all slots in the MM to build."
 
-	^ inverseSlotDic at: anObject class ifAbsentPut: [ anObject class slotNamed: self inverseName ]
+	^ anObject class slotNamed: self inverseName
 ]
 
 { #category : 'internal' }
@@ -204,12 +195,6 @@ FMRelationSlot >> removeAssociationFrom: ownerObject to: otherObject [
 	realInverseSlot isToOne
 		ifTrue: [ realInverseSlot writeInverse: nil to: otherObject ]
 		ifFalse: [ (realInverseSlot read: otherObject) unsafeRemove: ownerObject ]
-]
-
-{ #category : 'initialization' }
-FMRelationSlot >> resetInverseSlotsCache [
-
-	inverseSlotDic := IdentityDictionary new
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
We did other optimizations since this one and now it is not that needed anymore and we have currently a lot of bugs related to this cache.