### PR TITLE
Avoid double initialization of method comments

### DIFF
--- a/src/Fame-Core/FMMetaModelBuilder.class.st
+++ b/src/Fame-Core/FMMetaModelBuilder.class.st
@@ -250,7 +250,6 @@ FMMetaModelBuilder >> processCompiledMethod: aMethod [
 		ifFound: [ :pragma | 
 			| prop |
 			prop := FM3Property named: (pragma argumentAt: 1) asString.
-			method comment ifNotNil: [ :c | prop comment: c ].
 			typeDict at: prop put: (pragma argumentAt: 2).
 			mmClassDict at: prop put: method methodClass.
 			pragma selector = #FMProperty:type:defaultValue: ifTrue: [ prop defaultValue: (pragma argumentAt: 3) ].


### PR DESCRIPTION
Comments of properties are set via the FMComment: pragma. But we were also parsing the full methods to process to look for comments. 

This change removes this duplication making the building of the MM faster