### PR TITLE
Remove support for old MSE pragmas

### DIFF
--- a/src/Fame-Core/FMMetaModelBuilder.class.st
+++ b/src/Fame-Core/FMMetaModelBuilder.class.st
@@ -243,21 +243,17 @@ FMMetaModelBuilder >> processCompiledMethod: aMethod [
 			          compiledMethod ].
 	self assert: method isCompiledMethod.
 
-	"29 of October 2019: The MSEProperty:type:(opposite:) pragma is deprecated and should not be used anymore. But we still keep it for some time for backward compatibility."
 	method pragmas
 		detect: [ :each | 
-			#( #MSEProperty:type:opposite: #MSEProperty:type: #FMProperty:type:opposite: #FMProperty:type: #FMProperty:type:defaultValue: ) includes: each selector ]
+			#(#FMProperty:type:opposite: #FMProperty:type: #FMProperty:type:defaultValue: ) includes: each selector ]
 		ifFound: [ :pragma | 
 			| prop |
 			prop := FM3Property named: (pragma argumentAt: 1) asString.
 			typeDict at: prop put: (pragma argumentAt: 2).
 			mmClassDict at: prop put: method methodClass.
 			pragma selector = #FMProperty:type:defaultValue: ifTrue: [ prop defaultValue: (pragma argumentAt: 3) ].
-			(pragma selector = #FMProperty:type: 
-				and: [ method pragmas anySatisfy: [ :p | p selector = #withDefaultValueFromType ] ]) 
-					ifTrue: [ prop hasDefaultValueFromType: true ].
-			(pragma selector = #MSEProperty:type:opposite: or: [ pragma selector = #FMProperty:type:opposite: ]) ifTrue: [ 
-				oppositeDict at: prop put: (pragma argumentAt: 3) ].
+			(pragma selector = #FMProperty:type: and: [ method pragmas anySatisfy: [ :p | p selector = #withDefaultValueFromType ] ]) ifTrue: [ prop hasDefaultValueFromType: true ].
+			(pragma selector = #FMProperty:type:opposite: ) ifTrue: [ oppositeDict at: prop put: (pragma argumentAt: 3) ].
 			self processInfosFrom: method for: prop.
 
 			elements add: prop ]
@@ -265,6 +261,7 @@ FMMetaModelBuilder >> processCompiledMethod: aMethod [
 
 { #category : 'private' }
 FMMetaModelBuilder >> processInfosFrom: aMethod for: prop [
+
 	prop implementingSelector: aMethod selector.
 	self extractPackageFrom: aMethod for: prop.
 	(aMethod pragmaAt: #container) ifNotNil: [ prop isContainer: true ].
@@ -272,10 +269,8 @@ FMMetaModelBuilder >> processInfosFrom: aMethod for: prop [
 	(aMethod pragmaAt: #source) ifNotNil: [ prop isSource: true ].
 	(aMethod pragmaAt: #target) ifNotNil: [ prop isTarget: true ].
 	(aMethod pragmaAt: #multivalued) ifNotNil: [ prop isMultivalued: true ].
-	
-	(aMethod pragmaAt: #FMComment:) ifNotNil: [ :pragma | prop comment: (pragma argumentAt: 1) ].
-	self flag: #todo. "Next line should be removed in Moose 9 since the pragmas starting by MSE should be updated to the FM version."
-	(aMethod pragmaAt: #MSEComment:) ifNotNil: [ :pragma | prop comment: (pragma argumentNamed: #MSEComment) ]
+
+	(aMethod pragmaAt: #FMComment:) ifNotNil: [ :pragma | prop comment: (pragma argumentAt: 1) ]
 ]
 
 { #category : 'private' }

--- a/src/Fame-Core/Metaclass.extension.st
+++ b/src/Fame-Core/Metaclass.extension.st
@@ -7,11 +7,8 @@ Metaclass >> isMetamodelEntity [
 
 { #category : '*Fame-Core' }
 Metaclass >> metamodelDefinitionPragma [
-	"29 of October 2019: The MSEClass:super: pragma is deprecated and should not be used anymore. But we still keep it for some time for backward compatibility."
 
-	^ (Pragma allNamed: #FMClass:super: in: self) , (Pragma allNamed: #MSEClass:super: in: self)
-		ifEmpty: [ nil ]
-		ifNotEmpty: [ :p | 
-			p size = 1 ifFalse: [ self error: 'It should not be possible to have two pragmas to define a FM3 class.' ].
-			p anyOne ]
+	^ (Pragma allNamed: #FMClass:super: in: self) ifEmpty: [ nil ] ifNotEmpty: [ :p |
+			  p size = 1 ifFalse: [ self error: 'It should not be possible to have two pragmas to define a FM3 class.' ].
+			  p anyOne ]
 ]

--- a/src/Fame-ImportExport/Boolean.extension.st
+++ b/src/Fame-ImportExport/Boolean.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'Boolean' }
 
 { #category : '*Fame-ImportExport' }
-Boolean >> msePrintOn: aStream [
+Boolean >> famePrintOn: aStream [
 	self printOn: aStream
 ]

--- a/src/Fame-ImportExport/FMJSONPrinter.class.st
+++ b/src/Fame-ImportExport/FMJSONPrinter.class.st
@@ -78,7 +78,7 @@ FMJSONPrinter >> primitive: value [
 					charToPrint := $t ].
 				stream nextPut: (charToPrint ifNil: [ char ]) ].
 			stream nextPut: $" ]
-		ifFalse: [ value msePrintOn: stream ]
+		ifFalse: [ value famePrintOn: stream ]
 ]
 
 { #category : 'parsing' }

--- a/src/Fame-ImportExport/FMMSEPrinter.class.st
+++ b/src/Fame-ImportExport/FMMSEPrinter.class.st
@@ -67,7 +67,7 @@ FMMSEPrinter >> endProperty: name [
 { #category : 'parsing' }
 FMMSEPrinter >> primitive: value [
 	stream space.
-	value msePrintOn: stream
+	value famePrintOn: stream
 ]
 
 { #category : 'parsing' }

--- a/src/Fame-ImportExport/FMModel.extension.st
+++ b/src/Fame-ImportExport/FMModel.extension.st
@@ -78,9 +78,9 @@ FMModel >> importJSONStream: aReadStream [
 ]
 
 { #category : '*Fame-ImportExport' }
-FMModel >> importJSONString: mseString [
+FMModel >> importJSONString: jsonString [
 
-	self importJSONStream: mseString readStream
+	self importJSONStream: jsonString readStream
 ]
 
 { #category : '*Fame-ImportExport' }
@@ -92,7 +92,7 @@ FMModel >> importStream: aReadStream [
 ]
 
 { #category : '*Fame-ImportExport' }
-FMModel >> importString: mseString [
+FMModel >> importString: string [
 
-	self importStream: mseString readStream
+	self importStream: string readStream
 ]

--- a/src/Fame-ImportExport/Fraction.extension.st
+++ b/src/Fame-ImportExport/Fraction.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'Fraction' }
 
 { #category : '*Fame-ImportExport' }
-Fraction >> msePrintOn: stream [
-	self asFloat msePrintOn: stream
+Fraction >> famePrintOn: stream [
+	self asFloat famePrintOn: stream
 ]

--- a/src/Fame-ImportExport/Number.extension.st
+++ b/src/Fame-ImportExport/Number.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'Number' }
 
 { #category : '*Fame-ImportExport' }
-Number >> msePrintOn: aStream [
+Number >> famePrintOn: aStream [
 	self printOn: aStream
 ]

--- a/src/Fame-ImportExport/Object.extension.st
+++ b/src/Fame-ImportExport/Object.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : 'Object' }
 
 { #category : '*Fame-ImportExport' }
+Object >> famePrintOn: aStream [
+	self error: 'This type of object cannot be exported by fame ' , self class printString
+]
+
+{ #category : '*Fame-ImportExport' }
 Object >> handleFameProperty: aSymbol value: anObject [
 	"Override me if you want your object to deal with undefined properties loaded from a JSON.
 	
@@ -25,9 +30,4 @@ Object >> handleFameProperty: aSymbol value: anObject [
 { #category : '*Fame-ImportExport' }
 Object >> isDanglingReference [
 	^ false
-]
-
-{ #category : '*Fame-ImportExport' }
-Object >> msePrintOn: aStream [
-	self error: 'This type of object cannot be exported in a mse: ' , self class printString
 ]

--- a/src/Fame-ImportExport/String.extension.st
+++ b/src/Fame-ImportExport/String.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'String' }
 
 { #category : '*Fame-ImportExport' }
-String >> msePrintOn: aStream [
+String >> famePrintOn: aStream [
 	self printOn: aStream
 ]

--- a/src/Fame-ImportExport/Symbol.extension.st
+++ b/src/Fame-ImportExport/Symbol.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : 'Symbol' }
 
 { #category : '*Fame-ImportExport' }
-Symbol >> msePrintOn: aStream [
+Symbol >> famePrintOn: aStream [
 	| x |
 	aStream nextPut: $'.
 	1 to: self size do: [ :i | 


### PR DESCRIPTION
Those have been deprecated since 2019. It's time to remove them.

I also did some renaming to remove MSE from names that are not related to the MSE format