### PR TITLE
Remove defaultValueFromType from FM3Property

### DIFF
--- a/src/Fame-Core/FM3Property.class.st
+++ b/src/Fame-Core/FM3Property.class.st
@@ -61,8 +61,7 @@ Class {
 		'implementingSelector',
 		'isTarget',
 		'isSource',
-		'defaultValue',
-		'hasDefaultValueFromType'
+		'defaultValue'
 	],
 	#category : 'Fame-Core-Model',
 	#package : 'Fame-Core',
@@ -117,19 +116,6 @@ FM3Property >> getRawFrom: element [
 FM3Property >> hasDefaultValue [
 	^ defaultValue isNotNil 
 	
-]
-
-{ #category : 'private' }
-FM3Property >> hasDefaultValueFromType [
-
-	<FMProperty: #hasDefaultValueFromType type: #Boolean>
-	^ hasDefaultValueFromType
-]
-
-{ #category : 'private' }
-FM3Property >> hasDefaultValueFromType: aBoolean [
-
-	hasDefaultValueFromType := aBoolean
 ]
 
 { #category : 'testing' }

--- a/src/Fame-Core/FMMetaModelBuilder.class.st
+++ b/src/Fame-Core/FMMetaModelBuilder.class.st
@@ -237,26 +237,28 @@ FMMetaModelBuilder >> processCompiledMethod: aMethod [
 
 	"If the method is a reflective method we need to ensure it is compiled and use its compiled method.
 	A refelctive method is for exemple a method created via a metalink and that was never executed."
-	(aMethod isKindOf: ReflectiveMethod) ifTrue: [ 
-		method := aMethod
-			          compileAndInstallCompiledMethod;
-			          compiledMethod ].
+	(aMethod isKindOf: ReflectiveMethod) ifTrue: [
+			method := aMethod
+				          compileAndInstallCompiledMethod;
+				          compiledMethod ].
 	self assert: method isCompiledMethod.
 
 	method pragmas
-		detect: [ :each | 
-			#(#FMProperty:type:opposite: #FMProperty:type: #FMProperty:type:defaultValue: ) includes: each selector ]
-		ifFound: [ :pragma | 
-			| prop |
-			prop := FM3Property named: (pragma argumentAt: 1) asString.
-			typeDict at: prop put: (pragma argumentAt: 2).
-			mmClassDict at: prop put: method methodClass.
-			pragma selector = #FMProperty:type:defaultValue: ifTrue: [ prop defaultValue: (pragma argumentAt: 3) ].
-			(pragma selector = #FMProperty:type: and: [ method pragmas anySatisfy: [ :p | p selector = #withDefaultValueFromType ] ]) ifTrue: [ prop hasDefaultValueFromType: true ].
-			(pragma selector = #FMProperty:type:opposite: ) ifTrue: [ oppositeDict at: prop put: (pragma argumentAt: 3) ].
-			self processInfosFrom: method for: prop.
+		detect: [ :each |
+				#( #FMProperty:type:opposite: #FMProperty:type: #FMProperty:type:defaultValue: )
+					includes: each selector ]
+		ifFound: [ :pragma |
+				| prop |
+				prop := FM3Property named: (pragma argumentAt: 1) asString.
+				typeDict at: prop put: (pragma argumentAt: 2).
+				mmClassDict at: prop put: method methodClass.
+				pragma selector = #FMProperty:type:defaultValue: ifTrue: [
+					prop defaultValue: (pragma argumentAt: 3) ].
+				pragma selector = #FMProperty:type:opposite: ifTrue: [
+					oppositeDict at: prop put: (pragma argumentAt: 3) ].
+				self processInfosFrom: method for: prop.
 
-			elements add: prop ]
+				elements add: prop ]
 ]
 
 { #category : 'private' }

--- a/src/Fame-Tests/FMMetaMetaModelTest.class.st
+++ b/src/Fame-Tests/FMMetaMetaModelTest.class.st
@@ -117,8 +117,8 @@ FMMetaMetaModelTest >> testFM3IsComplete [
 	self assert: (names includes: 'FM3.Trait.root').
 	self assert: (names includes: 'FM3.Trait.users').
 	self assert: (names includes: 'FM3.Property.defaultValue').
-	self assert: names size equals: 34.
-	self assert: (names select: [ :n | n beginsWith: 'FM3.' ]) size equals: 33
+	self assert: names size equals: 33.
+	self assert: (names select: [ :n | n beginsWith: 'FM3.' ]) size equals: 32
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
This had been added to allow a default value for all properties of a type but it is not used and does not really make sense