### PR TITLE
Fix #isMetamodelEntity to not take traits into account

### DIFF
--- a/src/Fame-Core/Metaclass.extension.st
+++ b/src/Fame-Core/Metaclass.extension.st
@@ -7,8 +7,9 @@ Metaclass >> isMetamodelEntity [
 
 { #category : '*Fame-Core' }
 Metaclass >> metamodelDefinitionPragma [
+	"We take into account only pragmas that are in my methods and not methods from my traits."
 
-	^ (Pragma allNamed: #FMClass:super: in: self) ifEmpty: [ nil ] ifNotEmpty: [ :p |
-			  p size = 1 ifFalse: [ self error: 'It should not be possible to have two pragmas to define a FM3 class.' ].
-			  p anyOne ]
+	^ ((Pragma allNamed: #FMClass:super: in: self) select: [ :pragma | pragma method origin = self ]) ifEmpty: [ nil ] ifNotEmpty: [ :pragmas |
+			  pragmas size = 1 ifFalse: [ self error: 'It should not be possible to have two pragmas to define a FM3 class.' ].
+			  pragmas anyOne ]
 ]


### PR DESCRIPTION
With the previous implementation if a class used a metadescribed trait it was considered as metadescribed. But this should be true only if the annotation is on the class itself 

This will help to fix an issue in the Famix generator