### PR TITLE
Fixing allPropertiesDo properties duplications

### DIFF
--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -75,13 +75,6 @@ FM3Class >> allProperties [
 	^ nameDict values asArray
 ]
 
-{ #category : 'enumerating' }
-FM3Class >> allPropertiesDo: block [
-	properties do: block.
-	self superclass ifNotNil: [ :class | class allPropertiesDo: block ].
-	self traits do: [ :trait | trait allPropertiesDo: block ]
-]
-
 { #category : 'accessing' }
 FM3Class >> allSubclasses [
 	| all |

--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -62,12 +62,9 @@ FM3Class >> accept: aVisitor [
 { #category : 'accessing-query' }
 FM3Class >> allProperties [
 
-	<FMProperty: #allProperties type: 'FM3.Property'>
-	<multivalued>
-	<derived>
 	| nameDict |
 	nameDict := Dictionary new: 60. "estimated initial size."
-	super allProperties do: [ :each | nameDict at: each name ifAbsentPut: [ each ] ].
+	super allProperties do: [ :each |nameDict at: each name ifAbsentPut: [ each ] ].
 	self superclass ifNotNil: [ :class |
 			class allProperties do: [ :each |
 				nameDict at: each name ifAbsentPut: [ each ] ] ].

--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -59,6 +59,22 @@ FM3Class >> accept: aVisitor [
 	^ aVisitor visitClass: self
 ]
 
+{ #category : 'accessing-query' }
+FM3Class >> allProperties [
+
+	<FMProperty: #allProperties type: 'FM3.Property'>
+	<multivalued>
+	<derived>
+	| nameDict |
+	nameDict := Dictionary new: 60. "estimated initial size."
+	super allProperties do: [ :each | nameDict at: each name ifAbsentPut: [ each ] ].
+	self superclass ifNotNil: [ :class |
+			class allProperties do: [ :each |
+				nameDict at: each name ifAbsentPut: [ each ] ] ].
+
+	^ nameDict values asArray
+]
+
 { #category : 'enumerating' }
 FM3Class >> allPropertiesDo: block [
 	properties do: block.

--- a/src/Fame-Core/FM3Type.class.st
+++ b/src/Fame-Core/FM3Type.class.st
@@ -46,12 +46,16 @@ FM3Type >> allPrimitiveProperties [
 
 { #category : 'accessing-query' }
 FM3Type >> allProperties [
+
 	<FMProperty: #allProperties type: 'FM3.Property'>
 	<multivalued>
 	<derived>
 	| nameDict |
-	nameDict := Dictionary new: 60.	"estimated initial size."
-	self allPropertiesDo: [ :each | nameDict at: each name ifAbsentPut: [ each ] ].
+	nameDict := Dictionary new: 60. "estimated initial size."
+	self properties do: [ :each | nameDict at: each name ifAbsentPut: [ each ] ].
+	self traits do: [ :trait |
+			trait allPropertiesDo: [ :each |
+				nameDict at: each name ifAbsentPut: [ each ] ] ].
 	^ nameDict values asArray
 ]
 

--- a/src/Fame-Core/FM3Type.class.st
+++ b/src/Fame-Core/FM3Type.class.st
@@ -61,8 +61,7 @@ FM3Type >> allProperties [
 
 { #category : 'enumerating' }
 FM3Type >> allPropertiesDo: block [
-	self properties do: block.
-	self traits do: [ :trait | trait allPropertiesDo: block ]
+	self allProperties do: block.
 ]
 
 { #category : 'accessing-query' }

--- a/src/Fame-Tests/FM3ClassTest.class.st
+++ b/src/Fame-Tests/FM3ClassTest.class.st
@@ -25,6 +25,21 @@ FM3ClassTest >> testAllProperties [
 ]
 
 { #category : 'tests' }
+FM3ClassTest >> testAllPropertiesHasNoDuplication [
+
+	| mooseDesc numberOfProperties expectedNumberOfProperties |
+	mooseDesc := FamixJavaClass metadescription.
+
+	numberOfProperties := 0.
+	mooseDesc allPropertiesDo: [ :each |
+		numberOfProperties := numberOfProperties + 1 ].
+
+	expectedNumberOfProperties := mooseDesc allProperties size.
+
+	self assert: numberOfProperties equals: expectedNumberOfProperties
+]
+
+{ #category : 'tests' }
 FM3ClassTest >> testAllPropertiesMoreThanProperties [
 	element := metaMetamodel elementNamed: 'FM3.Class'.
 	self assert: element allProperties size > element properties size.

--- a/src/Fame-Tests/FM3ClassTest.class.st
+++ b/src/Fame-Tests/FM3ClassTest.class.st
@@ -25,6 +25,25 @@ FM3ClassTest >> testAllProperties [
 ]
 
 { #category : 'tests' }
+FM3ClassTest >> testAllPropertiesDoGiveSameElementsAsAllProperties [
+
+	| desc listWithPropDo listWithoutPropDo |
+	desc := FamixJavaClass metadescription.
+
+	"collecting with allPropertiesDo:"
+	listWithPropDo := OrderedCollection new.
+	desc allPropertiesDo: [ :prop | listWithPropDo add: prop name ].
+
+	"collecting without allPropertiesDo:"
+	listWithoutPropDo := desc allProperties collect: [ :prop | prop name ].
+
+	"the two lists should be equals"
+	self
+		assert: listWithPropDo asArray sorted
+		equals: listWithoutPropDo asArray sorted
+]
+
+{ #category : 'tests' }
 FM3ClassTest >> testAllPropertiesHasNoDuplication [
 
 	| mooseDesc numberOfProperties expectedNumberOfProperties |


### PR DESCRIPTION
I fixed the way allPropertiesDo is working to avoid properties duplication.

We now build properties, traits and superclass in allProperties and not in allPropertiesDo.
We are using a dictionnary to avoid duplications.

I removed the duplicated allPropertiesDo: method from FM3Class. It now inherits the behavior from FM3Type.

allPropertiesDo now using allProperties himself.

Closes #118 