### PR TITLE
Fixing allPropertiesDo duplications v2

### DIFF
--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -201,18 +201,6 @@ FM3Class >> ownerProperties [
 ]
 
 { #category : 'accessing-query' }
-FM3Class >> populatePropertiesDictionary: nameDict [
-	"this method is used to avoid code duplication when filling dictionnary"
-
-	self properties do: [ :each |
-		nameDict at: each name ifAbsentPut: [ each ] ].
-
-	self traits do: [ :trait |
-			trait allPropertiesDo: [ :each |
-				nameDict at: each name ifAbsentPut: [ each ] ] ]
-]
-
-{ #category : 'accessing-query' }
 FM3Class >> primitiveProperties [
 	^ self properties select: [ :attr | attr type isPrimitive ]
 ]

--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -59,21 +59,6 @@ FM3Class >> accept: aVisitor [
 	^ aVisitor visitClass: self
 ]
 
-{ #category : 'accessing-query' }
-FM3Class >> allProperties [
-
-	^ cachedAllProperties ifNil: [
-			  | nameDict |
-			  nameDict := Dictionary new: 60. "estimated initial size."
-			  super allProperties do: [ :each |
-				  nameDict at: each name ifAbsentPut: [ each ] ].
-			  self superclass ifNotNil: [ :class |
-					  class allProperties do: [ :each |
-						  nameDict at: each name ifAbsentPut: [ each ] ] ].
-
-			  ^ cachedAllProperties := nameDict values asArray ]
-]
-
 { #category : 'accessing' }
 FM3Class >> allSubclasses [
 	| all |
@@ -117,6 +102,18 @@ FM3Class >> createInstance [
 	^ implementingClass
 		ifNil: [ FMRuntimeElement new description: self ]
 		ifNotNil: [ implementingClass new ]
+]
+
+{ #category : 'accessing-query' }
+FM3Class >> fillPropertiesDictionary: nameDict [
+	"this method is used to avoid code duplication when filling dictionnary"
+
+	super fillPropertiesDictionary: nameDict.
+
+	"adding superclasses"
+	self superclass ifNotNil: [ :class |
+			class allProperties do: [ :each |
+				nameDict at: each name ifAbsentPut: [ each ] ] ]
 ]
 
 { #category : 'testing' }

--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -75,13 +75,6 @@ FM3Class >> allProperties [
 	^ nameDict values asArray
 ]
 
-{ #category : 'enumerating' }
-FM3Class >> allPropertiesDo: block [
-	properties do: block.
-	self superclass ifNotNil: [ :class | class allPropertiesDo: block ].
-	self traits do: [ :trait | trait allPropertiesDo: block ]
-]
-
 { #category : 'accessing' }
 FM3Class >> allSubclasses [
 	| all |

--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -62,12 +62,9 @@ FM3Class >> accept: aVisitor [
 { #category : 'accessing-query' }
 FM3Class >> allProperties [
 
-	<FMProperty: #allProperties type: 'FM3.Property'>
-	<multivalued>
-	<derived>
 	| nameDict |
 	nameDict := Dictionary new: 60. "estimated initial size."
-	super allProperties do: [ :each | nameDict at: each name ifAbsentPut: [ each ] ].
+	super allProperties do: [ :each |nameDict at: each name ifAbsentPut: [ each ] ].
 	self superclass ifNotNil: [ :class |
 			class allProperties do: [ :each |
 				nameDict at: each name ifAbsentPut: [ each ] ] ].

--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -59,6 +59,22 @@ FM3Class >> accept: aVisitor [
 	^ aVisitor visitClass: self
 ]
 
+{ #category : 'accessing-query' }
+FM3Class >> allProperties [
+
+	<FMProperty: #allProperties type: 'FM3.Property'>
+	<multivalued>
+	<derived>
+	| nameDict |
+	nameDict := Dictionary new: 60. "estimated initial size."
+	super allProperties do: [ :each | nameDict at: each name ifAbsentPut: [ each ] ].
+	self superclass ifNotNil: [ :class |
+			class allProperties do: [ :each |
+				nameDict at: each name ifAbsentPut: [ each ] ] ].
+
+	^ nameDict values asArray
+]
+
 { #category : 'enumerating' }
 FM3Class >> allPropertiesDo: block [
 	properties do: block.

--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -204,6 +204,18 @@ FM3Class >> ownerProperties [
 ]
 
 { #category : 'accessing-query' }
+FM3Class >> populatePropertiesDictionary: nameDict [
+	"this method is used to avoid code duplication when filling dictionnary"
+
+	self properties do: [ :each |
+		nameDict at: each name ifAbsentPut: [ each ] ].
+
+	self traits do: [ :trait |
+			trait allPropertiesDo: [ :each |
+				nameDict at: each name ifAbsentPut: [ each ] ] ]
+]
+
+{ #category : 'accessing-query' }
 FM3Class >> primitiveProperties [
 	^ self properties select: [ :attr | attr type isPrimitive ]
 ]

--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -62,14 +62,16 @@ FM3Class >> accept: aVisitor [
 { #category : 'accessing-query' }
 FM3Class >> allProperties [
 
-	| nameDict |
-	nameDict := Dictionary new: 60. "estimated initial size."
-	super allProperties do: [ :each |nameDict at: each name ifAbsentPut: [ each ] ].
-	self superclass ifNotNil: [ :class |
-			class allProperties do: [ :each |
-				nameDict at: each name ifAbsentPut: [ each ] ] ].
+	^ cachedAllProperties ifNil: [
+			  | nameDict |
+			  nameDict := Dictionary new: 60. "estimated initial size."
+			  super allProperties do: [ :each |
+				  nameDict at: each name ifAbsentPut: [ each ] ].
+			  self superclass ifNotNil: [ :class |
+					  class allProperties do: [ :each |
+						  nameDict at: each name ifAbsentPut: [ each ] ] ].
 
-	^ nameDict values asArray
+			  ^ cachedAllProperties := nameDict values asArray ]
 ]
 
 { #category : 'accessing' }

--- a/src/Fame-Core/FM3Type.class.st
+++ b/src/Fame-Core/FM3Type.class.st
@@ -46,12 +46,16 @@ FM3Type >> allPrimitiveProperties [
 
 { #category : 'accessing-query' }
 FM3Type >> allProperties [
+
 	<FMProperty: #allProperties type: 'FM3.Property'>
 	<multivalued>
 	<derived>
 	| nameDict |
-	nameDict := Dictionary new: 60.	"estimated initial size."
-	self allPropertiesDo: [ :each | nameDict at: each name ifAbsentPut: [ each ] ].
+	nameDict := Dictionary new: 60. "estimated initial size."
+	self properties do: [ :each | nameDict at: each name ifAbsentPut: [ each ] ].
+	self traits do: [ :trait |
+			trait allPropertiesDo: [ :each |
+				nameDict at: each name ifAbsentPut: [ each ] ] ].
 	^ nameDict values asArray
 ]
 

--- a/src/Fame-Core/FM3Type.class.st
+++ b/src/Fame-Core/FM3Type.class.st
@@ -4,7 +4,8 @@ Class {
 	#instVars : [
 		'package',
 		'properties',
-		'traits'
+		'traits',
+		'cachedAllProperties'
 	],
 	#category : 'Fame-Core-Model',
 	#package : 'Fame-Core',
@@ -50,13 +51,15 @@ FM3Type >> allProperties [
 	<FMProperty: #allProperties type: 'FM3.Property'>
 	<multivalued>
 	<derived>
-	| nameDict |
-	nameDict := Dictionary new: 60. "estimated initial size."
-	self properties do: [ :each | nameDict at: each name ifAbsentPut: [ each ] ].
-	self traits do: [ :trait |
-			trait allPropertiesDo: [ :each |
-				nameDict at: each name ifAbsentPut: [ each ] ] ].
-	^ nameDict values asArray
+	^ cachedAllProperties ifNil: [
+			  | nameDict |
+			  nameDict := Dictionary new: 60. "estimated initial size."
+			  self properties do: [ :each |
+				  nameDict at: each name ifAbsentPut: [ each ] ].
+			  self traits do: [ :trait |
+					  trait allPropertiesDo: [ :each |
+						  nameDict at: each name ifAbsentPut: [ each ] ] ].
+			  cachedAllProperties := nameDict values asArray ]
 ]
 
 { #category : 'enumerating' }

--- a/src/Fame-Core/FM3Type.class.st
+++ b/src/Fame-Core/FM3Type.class.st
@@ -61,8 +61,7 @@ FM3Type >> allProperties [
 
 { #category : 'enumerating' }
 FM3Type >> allPropertiesDo: block [
-	self properties do: block.
-	self traits do: [ :trait | trait allPropertiesDo: block ]
+	self allProperties do: block.
 ]
 
 { #category : 'accessing-query' }

--- a/src/Fame-Core/FM3Type.class.st
+++ b/src/Fame-Core/FM3Type.class.st
@@ -54,17 +54,14 @@ FM3Type >> allProperties [
 	^ cachedAllProperties ifNil: [
 			  | nameDict |
 			  nameDict := Dictionary new: 60. "estimated initial size."
-			  self properties do: [ :each |
-				  nameDict at: each name ifAbsentPut: [ each ] ].
-			  self traits do: [ :trait |
-					  trait allPropertiesDo: [ :each |
-						  nameDict at: each name ifAbsentPut: [ each ] ] ].
+			  self fillPropertiesDictionary: nameDict.
 			  cachedAllProperties := nameDict values asArray ]
 ]
 
 { #category : 'enumerating' }
 FM3Type >> allPropertiesDo: block [
-	self allProperties do: block.
+
+	self allProperties do: block
 ]
 
 { #category : 'accessing-query' }

--- a/src/Fame-Core/FM3Type.class.st
+++ b/src/Fame-Core/FM3Type.class.st
@@ -81,6 +81,18 @@ FM3Type >> classUsers [
 	^ { self }
 ]
 
+{ #category : 'as yet unclassified' }
+FM3Type >> fillPropertiesDictionary: nameDict [
+	"this method is used to avoid code duplication when filling dictionnary"
+
+	self properties do: [ :each |
+		nameDict at: each name ifAbsentPut: [ each ] ].
+
+	self traits do: [ :trait |
+			trait allPropertiesDo: [ :each |
+				nameDict at: each name ifAbsentPut: [ each ] ] ]
+]
+
 { #category : 'initialization' }
 FM3Type >> initialize [
 	super initialize.

--- a/src/Fame-Tests/FM3ClassTest.class.st
+++ b/src/Fame-Tests/FM3ClassTest.class.st
@@ -25,6 +25,21 @@ FM3ClassTest >> testAllProperties [
 ]
 
 { #category : 'tests' }
+FM3ClassTest >> testAllPropertiesHasNoDuplication [
+
+	| mooseDesc numberOfProperties expectedNumberOfProperties |
+	mooseDesc := FamixJavaClass metadescription.
+
+	numberOfProperties := 0.
+	mooseDesc allPropertiesDo: [ :each |
+		numberOfProperties := numberOfProperties + 1 ].
+
+	expectedNumberOfProperties := mooseDesc allProperties size.
+
+	self assert: numberOfProperties equals: expectedNumberOfProperties
+]
+
+{ #category : 'tests' }
 FM3ClassTest >> testAllPropertiesMoreThanProperties [
 	element := metaMetamodel elementNamed: 'FM3.Class'.
 	self assert: element allProperties size > element properties size.

--- a/src/Fame-Tests/FM3ClassTest.class.st
+++ b/src/Fame-Tests/FM3ClassTest.class.st
@@ -27,35 +27,54 @@ FM3ClassTest >> testAllProperties [
 { #category : 'tests' }
 FM3ClassTest >> testAllPropertiesDoGiveSameElementsAsAllProperties [
 
-	| desc listWithPropDo listWithoutPropDo |
-	desc := FamixJavaClass metadescription.
+	| superclass class listWithPropDo listWithoutPropDo |
+	superclass := self actualClass named: 'Superclass'.
+	class := self actualClass named: 'Class'.
+	class superclass: superclass.
+
+	superclass properties: {
+			(FM3Property named: #isDead).
+			(FM3Property named: #numberOfLinesOfCode) }.
+	class properties: {
+			(FM3Property named: #isDead).
+			(FM3Property named: #cc) }.
 
 	"collecting with allPropertiesDo:"
 	listWithPropDo := OrderedCollection new.
-	desc allPropertiesDo: [ :prop | listWithPropDo add: prop name ].
+	class allPropertiesDo: [ :prop | listWithPropDo add: prop name ].
 
-	"collecting without allPropertiesDo:"
-	listWithoutPropDo := desc allProperties collect: [ :prop | prop name ].
+	"collecting with allProperties"
+	listWithoutPropDo := class allProperties collect: [ :prop |
+		                     prop name ].
 
 	"the two lists should be equals"
 	self
-		assert: listWithPropDo asArray sorted
-		equals: listWithoutPropDo asArray sorted
+		assert: listWithPropDo asArray sorted equals: listWithoutPropDo asArray sorted
 ]
 
 { #category : 'tests' }
 FM3ClassTest >> testAllPropertiesHasNoDuplication [
 
-	| mooseDesc numberOfProperties expectedNumberOfProperties |
-	mooseDesc := FamixJavaClass metadescription.
+	| superclass class numberOfProperties expectedNumberOfProperties |
+	superclass := self actualClass named: 'Superclass'.
+	class := self actualClass named: 'Class'.
+	class superclass: superclass.
+
+	superclass properties: {
+		(FM3Property named: #isDead).
+		(FM3Property named: #numberOfLinesOfCode) }.
+	class properties: {
+		(FM3Property named: #isDead).
+		(FM3Property named: #cc) }.
 
 	numberOfProperties := 0.
-	mooseDesc allPropertiesDo: [ :each |
+	class allPropertiesDo: [ :each |
 		numberOfProperties := numberOfProperties + 1 ].
 
-	expectedNumberOfProperties := mooseDesc allProperties size.
+	expectedNumberOfProperties := class allProperties size.
 
-	self assert: numberOfProperties equals: expectedNumberOfProperties
+	self assert: numberOfProperties equals: expectedNumberOfProperties.
+	self assert: numberOfProperties equals: 3
 ]
 
 { #category : 'tests' }

--- a/src/Fame-Tests/FM3ClassTest.class.st
+++ b/src/Fame-Tests/FM3ClassTest.class.st
@@ -25,6 +25,25 @@ FM3ClassTest >> testAllProperties [
 ]
 
 { #category : 'tests' }
+FM3ClassTest >> testAllPropertiesDoGiveSameElementsAsAllProperties [
+
+	| desc listWithPropDo listWithoutPropDo |
+	desc := FamixJavaClass metadescription.
+
+	"collecting with allPropertiesDo:"
+	listWithPropDo := OrderedCollection new.
+	desc allPropertiesDo: [ :prop | listWithPropDo add: prop name ].
+
+	"collecting without allPropertiesDo:"
+	listWithoutPropDo := desc allProperties collect: [ :prop | prop name ].
+
+	"the two lists should be equals"
+	self
+		assert: listWithPropDo asArray sorted
+		equals: listWithoutPropDo asArray sorted
+]
+
+{ #category : 'tests' }
 FM3ClassTest >> testAllPropertiesHasNoDuplication [
 
 	| mooseDesc numberOfProperties expectedNumberOfProperties |


### PR DESCRIPTION
Following up the PR #119 
I made a second version of the fix for duplication of properties.
Fixed this problem by putting back the original pattern to keep optimization, and adding a method. `allPropertiesDo: block visited: aSet` to filter the properties duplications that we encounter thanks to a set.
Is this version better @Gabriel-Darbord @jecisc ?

Closes #118 
