### PR TITLE
Fix FameOppositeClassNotExistRule

### DIFF
--- a/src/Fame-Rules/FameOppositeClassNotExistRule.class.st
+++ b/src/Fame-Rules/FameOppositeClassNotExistRule.class.st
@@ -34,6 +34,7 @@ FameOppositeClassNotExistRule class >> uniqueIdentifierName [
 FameOppositeClassNotExistRule >> basicCheck: aMethod [
 
 	((aMethod methodClass methodNamed: aMethod selector) pragmaAt: #FMProperty:type:opposite:) ifNotNil: [ :pragma |
-		self class environment at: (pragma argumentAt: 2) ifPresent: [ :oppositeClass | ^ true ] ].
+		self class environment at: (pragma argumentAt: 2) ifAbsent: [ :oppositeClass | ^ true ] ].
+
 	^ false
 ]


### PR DESCRIPTION
This rule was doing the opposite of what it said. I probably inverted a condition while migrating it from the old to the new rule system.

*done on my free time*